### PR TITLE
Ability to approve on other slack channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ Request
       * The value for `provision_class` should be the name of your provision class with spaces
         
         ie. class `ProvisionLBEndpoint` -> `"provision_class": "Provision LB Endpoint"`
-  * Optionally, you can add `approvers_channel` and `requesters_channel` fields in your request to specify the approvers and requesters channels respectively. If not provided, the function will look for APPROVERS_CHANNEL and REQUESTERS_CHANNEL environment variables by default.
+  * Optionally, you can add `approvers_channel` and `requesters_channel` fields in your request to specify the approvers and requesters channels respectively. 
+    * If added, add environment variables with the same values. 
+    * If not provided, the function will look for APPROVERS_CHANNEL and REQUESTERS_CHANNEL environment variables by default.
 
 Example:
 ``` bash

--- a/README.md
+++ b/README.md
@@ -42,11 +42,14 @@ Request
       * The value for `provision_class` should be the name of your provision class with spaces
         
         ie. class `ProvisionLBEndpoint` -> `"provision_class": "Provision LB Endpoint"`
+  * Optionally, you can add `approvers_channel` and `requesters_channel` fields in your request to specify the approvers and requesters channels respectively. If not provided, the function will look for APPROVERS_CHANNEL and REQUESTERS_CHANNEL environment variables by default.
 
 Example:
 ``` bash
 curl -X POST -H "Content-Type:application/json" https://REGION-PROJECT.cloudfunctions.net/slack-request -d '{
 	"provision_class": "Provision Service",
+    "approvers_channel": "APPROVERS_CHANNEL",
+    "requesters_channel": "REQUESTERS_CHANNEL",
 	"field1": "value1",
 	"field2": "value2",
 }'

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     author_email=EMAIL,
     python_requires=REQUIRES_PYTHON,
     url=URL,
-    version="0.1.0",
+    version="0.1.1",
     license='MIT',
     classifiers=[
         'License :: OSI Approved :: MIT License',

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     author_email=EMAIL,
     python_requires=REQUIRES_PYTHON,
     url=URL,
-    version="0.1.2",
+    version="0.1.0",
     license='MIT',
     classifiers=[
         'License :: OSI Approved :: MIT License',

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     author_email=EMAIL,
     python_requires=REQUIRES_PYTHON,
     url=URL,
-    version="0.1.0",
+    version="0.1.2",
     license='MIT',
     classifiers=[
         'License :: OSI Approved :: MIT License',

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -14,7 +14,7 @@ class SlackRequest:
         self.inputs = request.json
         print(self.inputs)
         self.name = self.inputs["provision_class"]
-        self.approving_team = self.inputs["approving_team"]
+        self.approving_team = None if self.inputs["approving_team"] is None else self.inputs["approving_team"]
         self.value = self.inputs # save inputs before hiding anything
         hide = self.inputs.get("hide")
         if hide:

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -113,14 +113,14 @@ class SlackRequest:
 
     def get_slack_channels(self, approving_team):
         """Get approvers and requesters channels from environment variables."""
-        try:
-            if approving_team is None:
-                approvers_channel = os.environ["APPROVERS_CHANNEL"]
-                requesters_channel = os.environ["REQUESTERS_CHANNEL"]
-            else:
-                approvers_channel = os.environ[f"{approving_team.upper()}_APPROVERS_CHANNEL"]
-                requesters_channel = os.environ[f"{approving_team.upper()}_REQUESTERS_CHANNEL"]
-            return approvers_channel, requesters_channel
-        except KeyError as e:
-            logger.error(f"Slack channel(s) not found: {e}")
-            raise e
+        # try:
+        if approving_team is None:
+            approvers_channel = os.environ["APPROVERS_CHANNEL"]
+            requesters_channel = os.environ["REQUESTERS_CHANNEL"]
+        else:
+            approvers_channel = os.environ[f"{approving_team.upper()}_APPROVERS_CHANNEL"]
+            requesters_channel = os.environ[f"{approving_team.upper()}_REQUESTERS_CHANNEL"]
+        return approvers_channel, requesters_channel
+        # except KeyError as e:
+        #     logger.error(f"Slack channel(s) not found: {e}")
+        #     raise e

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -12,7 +12,6 @@ class SlackRequest:
         """requesters_channel only necessary for `pending` messages
         """
         self.inputs = request.json
-        print(self.inputs)
         self.name = self.inputs["provision_class"]
         self.approving_team = self.inputs.get("approving_team", None)
         self.value = self.inputs # save inputs before hiding anything

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -13,17 +13,21 @@ class SlackRequest:
         """
         self.inputs = request.json
         self.name = self.inputs["provision_class"]
-        self.approving_team = self.inputs.get("approving_team", None)
+        approving_team = self.inputs.get("approving_team", None)
         self.value = self.inputs # save inputs before hiding anything
+
         hide = self.inputs.get("hide")
         if hide:
             logger.info(f"Hidden fields: {hide}")
             for field in hide:
                 self.inputs.pop(field)
             self.inputs.pop("hide")
-        self.inputs.pop("approving_team")
+
+        if approving_team:
+            self.inputs.pop("approving_team")
+
         self.token = os.environ.get("SLACK_BOT_TOKEN")
-        self.approvers_channel, self.requesters_channel = self.get_slack_channels(self.approving_team)
+        self.approvers_channel, self.requesters_channel = self.get_slack_channels(approving_team)
 
     def send_request_message(self):
         slack_web_client = WebClient(self.token)

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -13,7 +13,7 @@ class SlackRequest:
         """
         self.inputs = request.json
         self.name = self.inputs["provision_class"]
-        # self.approving_team = self.inputs.get("approving_team", None)
+        self.approving_team = self.inputs.get("approving_team", None)
         self.value = self.inputs # save inputs before hiding anything
         hide = self.inputs.get("hide")
         if hide:
@@ -21,8 +21,9 @@ class SlackRequest:
             for field in hide:
                 self.inputs.pop(field)
             self.inputs.pop("hide")
+        self.inputs.pop("approving_team")
         self.token = os.environ.get("SLACK_BOT_TOKEN")
-        self.approvers_channel, self.requesters_channel = self.get_slack_channels()
+        self.approvers_channel, self.requesters_channel = self.get_slack_channels(self.approving_team)
 
     def send_request_message(self):
         slack_web_client = WebClient(self.token)
@@ -111,10 +112,8 @@ class SlackRequest:
         except errors.SlackApiError as e:
             logger.error(e)
 
-    def get_slack_channels(self):
+    def get_slack_channels(self, approving_team):
         """Get approvers and requesters channels from environment variables."""
-        
-        approving_team = self.inputs.get("approving_team", None)
         try:
             if approving_team is None:
                 approvers_channel = os.environ["APPROVERS_CHANNEL"]

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -12,6 +12,7 @@ class SlackRequest:
         """requesters_channel only necessary for `pending` messages
         """
         self.inputs = request.json
+        print(self.inputs)
         self.name = self.inputs["provision_class"]
         self.approving_team = self.inputs["approving_team"]
         self.value = self.inputs # save inputs before hiding anything

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -24,6 +24,12 @@ class SlackRequest:
         self.approvers_channel = os.environ[self.inputs.get("approvers_channel", "APPROVERS_CHANNEL")]
         self.requesters_channel = os.environ[self.inputs.get("requesters_channel", "REQUESTERS_CHANNEL")]
 
+        if self.inputs.get("requesters_channel"):
+            self.inputs.pop("requesters_channel")
+        
+        if self.inputs.get("approvers_channel"):
+            self.inputs.pop("approvers_channel")
+
     def send_request_message(self):
         slack_web_client = WebClient(self.token)
         blocks = [

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -13,7 +13,7 @@ class SlackRequest:
         """
         self.inputs = request.json
         self.name = self.inputs["provision_class"]
-        self.approving_team = self.inputs.get("approving_team", None)
+        # self.approving_team = self.inputs.get("approving_team", None)
         self.value = self.inputs # save inputs before hiding anything
         hide = self.inputs.get("hide")
         if hide:
@@ -22,7 +22,7 @@ class SlackRequest:
                 self.inputs.pop(field)
             self.inputs.pop("hide")
         self.token = os.environ.get("SLACK_BOT_TOKEN")
-        self.approvers_channel, self.requesters_channel = self.get_slack_channels(self.approving_team)
+        self.approvers_channel, self.requesters_channel = self.get_slack_channels()
 
     def send_request_message(self):
         slack_web_client = WebClient(self.token)
@@ -111,8 +111,10 @@ class SlackRequest:
         except errors.SlackApiError as e:
             logger.error(e)
 
-    def get_slack_channels(self, approving_team):
+    def get_slack_channels(self):
         """Get approvers and requesters channels from environment variables."""
+        
+        approving_team = self.inputs.get("approving_team", None)
         # try:
         if approving_team is None:
             approvers_channel = os.environ["APPROVERS_CHANNEL"]

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -115,14 +115,14 @@ class SlackRequest:
         """Get approvers and requesters channels from environment variables."""
         
         approving_team = self.inputs.get("approving_team", None)
-        # try:
-        if approving_team is None:
-            approvers_channel = os.environ["APPROVERS_CHANNEL"]
-            requesters_channel = os.environ["REQUESTERS_CHANNEL"]
-        else:
-            approvers_channel = os.environ[f"{approving_team.upper()}_APPROVERS_CHANNEL"]
-            requesters_channel = os.environ[f"{approving_team.upper()}_REQUESTERS_CHANNEL"]
-        return approvers_channel, requesters_channel
-        # except KeyError as e:
-        #     logger.error(f"Slack channel(s) not found: {e}")
-        #     raise e
+        try:
+            if approving_team is None:
+                approvers_channel = os.environ["APPROVERS_CHANNEL"]
+                requesters_channel = os.environ["REQUESTERS_CHANNEL"]
+            else:
+                approvers_channel = os.environ[f"{approving_team.upper()}_APPROVERS_CHANNEL"]
+                requesters_channel = os.environ[f"{approving_team.upper()}_REQUESTERS_CHANNEL"]
+            return approvers_channel, requesters_channel
+        except KeyError as e:
+            logger.error(f"Slack channel(s) not found: {e}")
+            raise e

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -13,21 +13,16 @@ class SlackRequest:
         """
         self.inputs = request.json
         self.name = self.inputs["provision_class"]
-        approving_team = self.inputs.get("approving_team", None)
         self.value = self.inputs # save inputs before hiding anything
-
         hide = self.inputs.get("hide")
         if hide:
             logger.info(f"Hidden fields: {hide}")
             for field in hide:
                 self.inputs.pop(field)
             self.inputs.pop("hide")
-
-        if approving_team:
-            self.inputs.pop("approving_team")
-
         self.token = os.environ.get("SLACK_BOT_TOKEN")
-        self.approvers_channel, self.requesters_channel = self.get_slack_channels(approving_team)
+        self.approvers_channel = os.environ[self.inputs.get("approvers_channel", "APPROVERS_CHANNEL")]
+        self.requesters_channel = os.environ[self.inputs.get("requesters_channel", "REQUESTERS_CHANNEL")]
 
     def send_request_message(self):
         slack_web_client = WebClient(self.token)
@@ -115,17 +110,3 @@ class SlackRequest:
             logger.info(response.status_code)
         except errors.SlackApiError as e:
             logger.error(e)
-
-    def get_slack_channels(self, approving_team):
-        """Get approvers and requesters channels from environment variables."""
-        try:
-            if approving_team is None:
-                approvers_channel = os.environ["APPROVERS_CHANNEL"]
-                requesters_channel = os.environ["REQUESTERS_CHANNEL"]
-            else:
-                approvers_channel = os.environ[f"{approving_team.upper()}_APPROVERS_CHANNEL"]
-                requesters_channel = os.environ[f"{approving_team.upper()}_REQUESTERS_CHANNEL"]
-            return approvers_channel, requesters_channel
-        except KeyError as e:
-            logger.error(f"Slack channel(s) not found: {e}")
-            raise e

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -14,7 +14,7 @@ class SlackRequest:
         self.inputs = request.json
         print(self.inputs)
         self.name = self.inputs["provision_class"]
-        self.approving_team = None if self.inputs["approving_team"] is None else self.inputs["approving_team"]
+        self.approving_team = self.inputs.get("approving_team", None)
         self.value = self.inputs # save inputs before hiding anything
         hide = self.inputs.get("hide")
         if hide:


### PR DESCRIPTION
### Changes
- Add a function to determine slack channel to direct requests to based on the `approvers_channel` and `requesters_channel` variables received in the payload.

### Testing
- Tested using looker template