### PR TITLE
Infra 1497 slack approvals ability to modify request in slack

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     author_email=EMAIL,
     python_requires=REQUIRES_PYTHON,
     url=URL,
-    version="0.1.5",
+    version="0.1.6",
     license='MIT',
     classifiers=[
         'License :: OSI Approved :: MIT License',

--- a/slack_approval/functions/provision.py
+++ b/slack_approval/functions/provision.py
@@ -4,25 +4,16 @@ from slack_approval.slack_provision import SlackProvision
 
 app = Goblet(function_name="provision")
 goblet_entrypoint(app)
-import logging
 
-logger = logging.getLogger("slack_provision")
-logger.setLevel(logging.DEBUG)
+
 @app.http()
 def main(request):
     """
     """
     slack_provision = SlackProvision(request)
     # validate request using the signature secret
-    # if not slack_provision.is_valid_signature(os.environ.get("SIGNING_SECRET")):
-    #     return Response("Forbidden", status_code=403)
+    if not slack_provision.is_valid_signature(os.environ.get("SIGNING_SECRET")):
+        return Response("Forbidden", status_code=403)
 
-    if hasattr(slack_provision, "name"):
-        try:
-            slack_provision.__class__ = globals()[slack_provision.name.replace(" ", "")]
-            slack_provision()
-        except Exception as e:
-            logger.info(f"Error {e}")
-            return Response("", status_code=200)
-    return Response("", status_code=200)
-
+    slack_provision.__class__ = globals()[slack_provision.name.replace(" ", "")]
+    slack_provision()

--- a/slack_approval/functions/provision.py
+++ b/slack_approval/functions/provision.py
@@ -23,6 +23,6 @@ def main(request):
             slack_provision()
         except Exception as e:
             logger.info(f"Error {e}")
-            return Response("ERROR", status_code=400)
+            return Response("OK", status_code=200)
     return Response("OK", status_code=200)
 

--- a/slack_approval/functions/provision.py
+++ b/slack_approval/functions/provision.py
@@ -15,6 +15,6 @@ def main(request):
     # if not slack_provision.is_valid_signature(os.environ.get("SIGNING_SECRET")):
     #     return Response("Forbidden", status_code=403)
 
-    if slack_provision.name != "":
+    if slack_provision.name and slack_provision.name != "" and slack_provision.name != "Slack Provision":
         slack_provision.__class__ = globals()[slack_provision.name.replace(" ", "")]
-    slack_provision()
+        slack_provision()

--- a/slack_approval/functions/provision.py
+++ b/slack_approval/functions/provision.py
@@ -12,12 +12,14 @@ def main(request):
     """
     slack_provision = SlackProvision(request)
     # validate request using the signature secret
-    # if not slack_provision.is_valid_signature(os.environ.get("SIGNING_SECRET")):
-    #     return Response("Forbidden", status_code=403)
+    if not slack_provision.is_valid_signature(os.environ.get("SIGNING_SECRET")):
+        return Response("Forbidden", status_code=403)
 
     if hasattr(slack_provision, "name"):
         try:
             slack_provision.__class__ = globals()[slack_provision.name.replace(" ", "")]
             slack_provision()
         except Exception as e:
-            return
+            return Response("OK", status_code=200)
+    return Response("OK", status_code=200)
+

--- a/slack_approval/functions/provision.py
+++ b/slack_approval/functions/provision.py
@@ -15,6 +15,9 @@ def main(request):
     # if not slack_provision.is_valid_signature(os.environ.get("SIGNING_SECRET")):
     #     return Response("Forbidden", status_code=403)
 
-    if hasattr(slack_provision, "name") and slack_provision.name and slack_provision.name != "" and slack_provision.name != "Slack Provision" and slack_provision.name != "SlackProvision":
-        slack_provision.__class__ = globals()[slack_provision.name.replace(" ", "")]
-        slack_provision()
+    if hasattr(slack_provision, "name"):
+        try:
+            slack_provision.__class__ = globals()[slack_provision.name.replace(" ", "")]
+            slack_provision()
+        except Exception as e:
+            return

--- a/slack_approval/functions/provision.py
+++ b/slack_approval/functions/provision.py
@@ -20,6 +20,6 @@ def main(request):
             slack_provision.__class__ = globals()[slack_provision.name.replace(" ", "")]
             slack_provision()
         except Exception as e:
-            return Response("OK", status_code=200)
+            return Response("ERROR", status_code=400)
     return Response("OK", status_code=200)
 

--- a/slack_approval/functions/provision.py
+++ b/slack_approval/functions/provision.py
@@ -15,6 +15,6 @@ def main(request):
     # if not slack_provision.is_valid_signature(os.environ.get("SIGNING_SECRET")):
     #     return Response("Forbidden", status_code=403)
 
-    if slack_provision.name and slack_provision.name != "" and slack_provision.name != "Slack Provision":
+    if slack_provision.name and slack_provision.name != "" and slack_provision.name != "Slack Provision" and slack_provision.name != "SlackProvision":
         slack_provision.__class__ = globals()[slack_provision.name.replace(" ", "")]
         slack_provision()

--- a/slack_approval/functions/provision.py
+++ b/slack_approval/functions/provision.py
@@ -12,8 +12,8 @@ def main(request):
     """
     slack_provision = SlackProvision(request)
     # validate request using the signature secret
-    if not slack_provision.is_valid_signature(os.environ.get("SIGNING_SECRET")):
-        return Response("Forbidden", status_code=403)
+    # if not slack_provision.is_valid_signature(os.environ.get("SIGNING_SECRET")):
+    #     return Response("Forbidden", status_code=403)
 
     if hasattr(slack_provision, "name"):
         try:

--- a/slack_approval/functions/provision.py
+++ b/slack_approval/functions/provision.py
@@ -15,6 +15,6 @@ def main(request):
     # if not slack_provision.is_valid_signature(os.environ.get("SIGNING_SECRET")):
     #     return Response("Forbidden", status_code=403)
 
-    if slack_provision.name and slack_provision.name != "" and slack_provision.name != "Slack Provision" and slack_provision.name != "SlackProvision":
+    if hasattr(slack_provision, "name") and slack_provision.name and slack_provision.name != "" and slack_provision.name != "Slack Provision" and slack_provision.name != "SlackProvision":
         slack_provision.__class__ = globals()[slack_provision.name.replace(" ", "")]
         slack_provision()

--- a/slack_approval/functions/provision.py
+++ b/slack_approval/functions/provision.py
@@ -23,6 +23,6 @@ def main(request):
             slack_provision()
         except Exception as e:
             logger.info(f"Error {e}")
-            return Response("OK", status_code=200)
-    return Response("OK", status_code=200)
+            return Response("", status_code=200)
+    return Response("", status_code=200)
 

--- a/slack_approval/functions/provision.py
+++ b/slack_approval/functions/provision.py
@@ -4,8 +4,10 @@ from slack_approval.slack_provision import SlackProvision
 
 app = Goblet(function_name="provision")
 goblet_entrypoint(app)
+import logging
 
-
+logger = logging.getLogger("slack_provision")
+logger.setLevel(logging.DEBUG)
 @app.http()
 def main(request):
     """
@@ -20,6 +22,7 @@ def main(request):
             slack_provision.__class__ = globals()[slack_provision.name.replace(" ", "")]
             slack_provision()
         except Exception as e:
+            logger.info(f"Error {e}")
             return Response("ERROR", status_code=400)
     return Response("OK", status_code=200)
 

--- a/slack_approval/functions/requirements-provision.txt
+++ b/slack_approval/functions/requirements-provision.txt
@@ -1,3 +1,3 @@
 goblet-gcp==0.9.2
 slack_sdk==3.18.1
-git+https://github.com/premisedata/slack-approval.git
+git+https://github.com/premisedata/slack-approval.git@INFRA-1497-Slack-approvals-ability-to-modify-request-in-slack

--- a/slack_approval/functions/requirements-provision.txt
+++ b/slack_approval/functions/requirements-provision.txt
@@ -1,3 +1,3 @@
 goblet-gcp==0.9.2
 slack_sdk==3.18.1
-git+https://github.com/premisedata/slack-approval.git@INFRA-1497-Slack-approvals-ability-to-modify-request-in-slack
+slack-approval @ git+https://github.com/premisedata/slack-approval.git@INFRA-1497-Slack-approvals-ability-to-modify-request-in-slack

--- a/slack_approval/functions/requirements-provision.txt
+++ b/slack_approval/functions/requirements-provision.txt
@@ -1,3 +1,3 @@
 goblet-gcp==0.9.2
 slack_sdk==3.18.1
-git+https://github.com/premisedata/slack-approval.git@INFRA-1615-slack-approvals-prevent-self-approval
+git+https://github.com/premisedata/slack-approval.git

--- a/slack_approval/functions/requirements-provision.txt
+++ b/slack_approval/functions/requirements-provision.txt
@@ -1,3 +1,3 @@
 goblet-gcp==0.9.2
 slack_sdk==3.18.1
-slack-approval @ git+https://github.com/premisedata/slack-approval.git@INFRA-1497-Slack-approvals-ability-to-modify-request-in-slack
+git+https://github.com/premisedata/slack-approval.git

--- a/slack_approval/functions/requirements-request.txt
+++ b/slack_approval/functions/requirements-request.txt
@@ -1,3 +1,3 @@
 goblet-gcp==0.9.2
 slack_sdk==3.18.1
-git+https://github.com/premisedata/slack-approval.git
+git+https://github.com/premisedata/slack-approval.git@INFRA-1497-Slack-approvals-ability-to-modify-request-in-slack

--- a/slack_approval/functions/requirements-request.txt
+++ b/slack_approval/functions/requirements-request.txt
@@ -1,3 +1,3 @@
 goblet-gcp==0.9.2
 slack_sdk==3.18.1
-git+https://github.com/premisedata/slack-approval.git@INFRA-1497-Slack-approvals-ability-to-modify-request-in-slack
+slack-approval @ git+https://github.com/premisedata/slack-approval.git@INFRA-1497-Slack-approvals-ability-to-modify-request-in-slack

--- a/slack_approval/functions/requirements-request.txt
+++ b/slack_approval/functions/requirements-request.txt
@@ -1,3 +1,3 @@
 goblet-gcp==0.9.2
 slack_sdk==3.18.1
-slack-approval @ git+https://github.com/premisedata/slack-approval.git@INFRA-1497-Slack-approvals-ability-to-modify-request-in-slack
+git+https://github.com/premisedata/slack-approval.git

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -66,7 +66,8 @@ class SlackProvision:
                 self.is_open_reason_view()
             elif self.action_id == "Not allowed":
                 message = f"Same request/response user {self.user} not allowed. Prevent self approval is on."
-                self.send_message_to_thread(message=message, thread_ts=self.ts, channel=self.requesters_channel)
+                self.send_message_to_thread(message=message, thread_ts=self.ts, channel=self.channel_id)
+                self.send_message_to_thread(message=message, thread_ts=self.message_ts, channel=self.requesters_channel)
             elif self.action_id == "Reject Response":
                 self.rejected()
                 message = f"Reason for rejection: {self.reason}"

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -230,6 +230,8 @@ class SlackProvision:
         self.token = metadata["token"]
         reason = self.payload['view']['state']['values']['reason_block']['reject_reason_input']['value']
         self.action_id = "Rejected with reason"
+        self.exception = None
+
         try:
             client = WebClient(self.token)
             client.chat_postMessage(

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -203,7 +203,6 @@ class SlackProvision:
             logger.error(e)
 
     def open_reject_reason_view(self):
-        logger.info(self.payload)
         private_metadata = {
             "channel_id": self.payload["channel"]["id"],
             "approvers_ts": self.payload["message"]["ts"],
@@ -322,6 +321,8 @@ class SlackProvision:
             logger.error(e)
 
     def open_edit_view(self):
+        logger.info(self.payload)
+
         private_metadata = {
             "channel_id": self.payload["channel"]["id"],
             "approvers_ts": self.payload["message"]["ts"],
@@ -332,7 +333,6 @@ class SlackProvision:
             "response_url": self.response_url,
             "requesters_channel": self.requesters_channel,
             "token": self.token,
-            "requesters_ts": self.requesters_ts,
             "modifiables_fields": self.modifiables_fields,
             "requester": self.requester,
             "approvers_channel": self.approvers_channel,

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -419,8 +419,8 @@ class SlackProvision:
 
         for block_name, block_values in blocks.items():
             new_value = block_values[f"action_id_{block_name}"]["value"]
-            if new_value is None:
-                new_value = ""
+            if new_value is None or new_value == "":
+                continue
             self.inputs["modified"] = True
             self.inputs[re.sub(r"_\d+$", '', block_name)].append(new_value)
 

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -322,20 +322,18 @@ class SlackProvision:
 
     def open_edit_view(self):
         logger.info(self.payload)
-
         private_metadata = {
             "channel_id": self.payload["channel"]["id"],
             "approvers_ts": self.payload["message"]["ts"],
-            "requesters_ts": self.requesters_ts,
             "name": self.inputs["provision_class"],
             "inputs": self.inputs,
             "user": self.user,
             "response_url": self.response_url,
             "requesters_channel": self.requesters_channel,
             "token": self.token,
-            "modifiables_fields": self.modifiables_fields,
-            "requester": self.requester,
+            "requesters_ts": self.requesters_ts,
             "approvers_channel": self.approvers_channel,
+            "requester": self.requester,
             "prevent_self_approval": self.prevent_self_approval,
         }
         try:

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -325,7 +325,7 @@ class SlackProvision:
 
         private_metadata = {
             "channel_id": self.payload["channel"]["id"],
-            "approvers_ts": self.payload["message"]["ts"],
+            "approvers_ts": self.payload["container"]["message_ts"],
             "requesters_ts": self.requesters_ts,
             "name": self.inputs["provision_class"],
             "inputs": self.inputs,

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -23,6 +23,9 @@ class SlackProvision:
         self.exception = None
         self.channel_id = None
         self.reason = None
+        self.user_payload = None
+        self.user = None
+        self.user_id = None
         self.token = os.environ.get("SLACK_BOT_TOKEN")
         self.data = request.get_data()
         self.headers = request.headers
@@ -41,12 +44,11 @@ class SlackProvision:
             self.get_modifications()
             return
 
-        self.user_payload = self.payload["user"]
         self.action = self.payload["actions"][0]
         self.inputs = json.loads(self.action["value"])
         self.response_url = self.payload["response_url"]
         self.action_id = self.action["action_id"]
-        self.user = self.parse_user()
+        self.get_user_info()
 
         self.name = self.inputs["provision_class"]
         self.requesters_ts = self.inputs.pop("requesters_ts")
@@ -221,10 +223,13 @@ class SlackProvision:
                 and self.payload["view"].get("callback_id", "") == callback_id
         )
 
-    def parse_user(self):
-        return " ".join(
-            [s.capitalize() for s in self.payload["user"]["name"].split(".")]
+    def get_user_info(self):
+        self.user_payload = self.payload["user"]
+        self.user = " ".join(
+            [s.capitalize() for s in self.user_payload["name"].split(".")]
         )
+        logger.info(self.user_payload)
+        self.user_id = self.user_payload["id"]
 
     def get_private_metadata(self):
         metadata = json.loads(self.payload["view"]["private_metadata"])

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -66,7 +66,7 @@ class SlackProvision:
                 self.open_reject_reason_view()
             elif self.action_id == "Not allowed":
                 message = f"Same request/response user {self.user} not allowed. Prevent self approval is on."
-                self.open_dialog(message=f"Not allowed for user {self.user}")
+                self.open_dialog(message=message)
                 self.send_message_to_thread(message=message, thread_ts=self.ts, channel=self.requesters_channel)
             elif self.action_id == "Reject Response":
                 self.rejected()

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -59,7 +59,7 @@ class SlackProvision:
             Backward compatibility: prevent_self_approval deactivated """
         self.prevent_self_approval = self.inputs.get("prevent_self_approval", False)
         self.inputs["modified"] = self.inputs.get("modified", False)
-
+        logger.info(f"prevent_self_approval {self.prevent_self_approval}")
         if not self.is_allowed():
             self.action_id = "Not allowed"
 

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -236,7 +236,7 @@ class SlackProvision:
             client = WebClient(self.token)
             client.chat_postMessage(
                 channel=channel_id,
-                thread_ts=ts,
+                thread_ts=self.ts,
                 text=f"Reason for denial: {reason}"
             )
         except errors.SlackApiError as e:

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -68,7 +68,7 @@ class SlackProvision:
             elif self.action_id == "Reject Response":
                 self.rejected()
                 self.send_reject_reason()
-                self.send_status_message()
+                self.send_status_message(requester_status="Rejected", approver_status="Rejected")
                 return
 
         except Exception as e:

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -196,7 +196,7 @@ class SlackProvision:
         values["requesters_channel"] = self.requesters_channel
         values["approvers_channel"] = self.approvers_channel
         values["modifiables_fields"] = ";".join(list(self.modifiables_fields.keys()))
-        edit_button = values["modifiables_fields"] is not None and values["modifiables_fields"] != ""
+        edit_button = values.get("modifiables_fields", None) is not None and values["modifiables_fields"] != ""
         approvers_blocks.extend(get_buttons_blocks(value=json.dumps(values), edit_button=edit_button))
         asyncio.run(self.send_message_requester_approver(requesters_blocks, approvers_blocks))
         # self.send_message_requester(requesters_blocks)

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -64,7 +64,7 @@ class SlackProvision:
                         "type": "modal",
                         "callback_id": "reason_modal",
                         "ts": self.ts,
-                        "requesters_channel":self.requesters_channel
+                        "requesters_channel":self.requesters_channel,
                         "title": {
                             "type": "plain_text",
                             "text": "Denial Reason"

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -67,7 +67,6 @@ class SlackProvision:
             elif self.action_id == "Not allowed":
                 message = f"Same request/response user {self.user} not allowed. Prevent self approval is on."
                 self.open_dialog(title="Warning", message=message)
-                self.send_message_to_thread(message=message, thread_ts=self.ts, channel=self.requesters_channel)
             elif self.action_id == "Reject Response":
                 self.rejected()
                 message = f"Reason for rejection: {self.reason}"
@@ -116,7 +115,7 @@ class SlackProvision:
             slack_web_client = WebClient(self.token)
             user_info = slack_web_client.users_info(user=self.user_payload["id"])
             user_email = user_info["user"]["profile"]["email"]
-            if user_email == self.requester:
+            if user_email == self.requester and self.action_id == "Approved":
                 return False
             else:
                 return True

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -83,7 +83,7 @@ class SlackProvision:
                 self.rejected()
                 message = f"reason for rejection: {self.reason}"
                 asyncio.run(self.send_notifications(message=message, mention_requester=True))
-                
+
 
 
             elif self.action_id == "Edit":
@@ -158,12 +158,12 @@ class SlackProvision:
         asyncio.run(self.send_message_approver(blocks))
         asyncio.run(self.send_message_requester(blocks))
 
-    async def send_message_to_thread(self, message, thread_ts, channel, mention_requester=False):
+    def send_message_to_thread(self, message, thread_ts, channel, mention_requester=False):
         try:
             if mention_requester:
                 message = f"<@{self.user_id}> {message}"
-            client = AsyncWebClient(self.token)
-            response = await client.chat_postMessage(
+            client = WebClient(self.token)
+            response = client.chat_postMessage(
                 channel=channel,
                 thread_ts=thread_ts,
                 text=message,
@@ -481,12 +481,12 @@ class SlackProvision:
         }
 
     async def send_notifications(self, message, mention_requester):
-        asyncio.run(self.send_message_to_thread(message=message,
+        self.send_message_to_thread(message=message,
                                                 thread_ts=self.requesters_ts,
                                                 channel=self.requesters_channel,
-                                                mention_requester=True))
+                                                mention_requester=True)
 
-        asyncio.run(self.send_message_to_thread(message=message,
+        self.send_message_to_thread(message=message,
                                                 thread_ts=self.approvers_ts,
                                                 channel=self.channel_id,
-                                                mention_requester=True))
+                                                mention_requester=True)

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -219,4 +219,4 @@ class SlackProvision:
         self.rejected()
 
     def from_reject_response(self):
-        return "view" in self.payload and "callback_id" in self.payload and self["callback_id"] == "reject_reason_modal"
+        return "view" in self.payload and "callback_id" in self.payload and self.payload["callback_id"] == "reject_reason_modal"

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -334,6 +334,25 @@ class SlackProvision:
         ) in self.modifiables_fields.items():
             if isinstance(modifiable_field_value, list):
                 item_number = 0
+                if len(modifiable_field_value) == 0:
+                    field = {
+                        "type": "input",
+                        "block_id": f"multivalue_block_id_{modifiable_field_name}_{item_number}",
+                        "label": {"type": "plain_text", "text": modifiable_field_name},
+                        "element": {
+                            "type": "plain_text_input",
+                            "action_id": f"action_id_{modifiable_field_name}_{item_number}",
+                            "placeholder": {
+                                "type": "plain_text",
+                                "text": "Insert value",
+                            },
+                            "initial_value": "no value",
+                            "multiline": False,
+                        },
+                        "optional": True,
+                    }
+                    blocks.append(field)
+                    continue
                 for value in modifiable_field_value:
                     value = value if value != "" else "no value"
                     field = {
@@ -345,7 +364,7 @@ class SlackProvision:
                             "action_id": f"action_id_{modifiable_field_name}_{item_number}",
                             "placeholder": {
                                 "type": "plain_text",
-                                "text": "value",
+                                "text": "Insert value",
                             },
                             "initial_value": value,
                             "multiline": False,
@@ -364,7 +383,7 @@ class SlackProvision:
                     "action_id": f"action_id_{modifiable_field_name}",
                     "placeholder": {
                         "type": "plain_text",
-                        "text": modifiable_field_value,
+                        "text": "Insert value",
                     },
                     "initial_value": modifiable_field_value,
                     "multiline": False,
@@ -423,6 +442,7 @@ class SlackProvision:
                 continue
             self.inputs["modified"] = True
             self.inputs[re.sub(r"_\d+$", '', block_name)].append(new_value)
+
 
     @staticmethod
     def construct_reason_modal(private_metadata):

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -321,7 +321,7 @@ class SlackProvision:
 
     def construct_modifiable_fields_blocks(self):
         blocks = [
-            {"type": "section", "text": {"type": "mrkdwn", "text": "Modifiable fields"}}
+            {"type": "section", "text": {"type": "mrkdwn", "text": "Modify fields (empty text to remove)"}}
         ]
         for (
                 modifiable_field_name,

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -12,10 +12,6 @@ logger = logging.getLogger("slack_provision")
 logger.setLevel(logging.DEBUG)
 
 
-
-
-
-
 class SlackProvision:
     def __init__(self, request, requesters_channel=None):
         self.exception = None
@@ -45,7 +41,7 @@ class SlackProvision:
             self.get_private_metadata()
             self.action_id = "Modified"
             self.get_modified_fields()
-            #self.send_modified_message()
+            # self.send_modified_message()
             return
 
         self.user_payload = self.payload["user"]
@@ -132,6 +128,7 @@ class SlackProvision:
         except errors.SlackApiError as e:
             self.exception = e
             logger.error(e)
+
     def send_message_requester(self, blocks):
         try:
             # Message to requester
@@ -157,13 +154,13 @@ class SlackProvision:
         blocks.extend(get_header_block(name=self.name))
         blocks.extend(get_inputs_blocks(inputs=self.inputs))
         values = {"provision_class": self.name, "ts": self.ts, "requesters_channel": self.requesters_channel,
-                  "approvers_channel": self.approvers_channel, "user": self.user, "requester": self.requester,
+                  "user": self.user, "requester": self.requester,
                   "modifiables_fields": self.modifiables_fields, "prevent_self_approval": self.prevent_self_approval}
 
         self.send_message_requester(blocks)
         blocks.extend(get_buttons_blocks(value=json.dumps(values)))
         self.send_message_approver(blocks)
-        
+
     def send_status_message(self, status):
         hide = self.inputs.get("hide")
         if hide:
@@ -266,9 +263,9 @@ class SlackProvision:
 
     def is_callback_view(self, callback_id):
         return (
-            self.payload.get("type", "") == "view_submission"
-            and self.payload.get("view", False)
-            and self.payload["view"].get("callback_id", "") == callback_id
+                self.payload.get("type", "") == "view_submission"
+                and self.payload.get("view", False)
+                and self.payload["view"].get("callback_id", "") == callback_id
         )
 
     def parse_user(self):
@@ -377,13 +374,13 @@ class SlackProvision:
         }
         try:
             modal_view = {
-                    "type": "modal",
-                    "callback_id": "edit_view_modal",
-                    "private_metadata": json.dumps(private_metadata),
-                    "title": {"type": "plain_text", "text": "Edit view"},
-                    "blocks": self.construct_modifiable_fields_blocks(),
-                    "submit": {"type": "plain_text", "text": "Save"},
-                }
+                "type": "modal",
+                "callback_id": "edit_view_modal",
+                "private_metadata": json.dumps(private_metadata),
+                "title": {"type": "plain_text", "text": "Edit view"},
+                "blocks": self.construct_modifiable_fields_blocks(),
+                "submit": {"type": "plain_text", "text": "Save"},
+            }
             client = WebClient(self.token)
             client.views_open(
                 trigger_id=self.payload["trigger_id"],
@@ -396,33 +393,33 @@ class SlackProvision:
 
     def construct_modifiable_fields_blocks(self):
         blocks = [{
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": "Modifiable fields"
-                    }
-                }
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "Modifiable fields"
+            }
+        }
         ]
         for modifiable_field_name, modifiable_field_value in self.modifiables_fields.items():
             field = {
-                    "type": "input",
-                    "block_id": f"block_id_{modifiable_field_name}",
-                    "label": {
+                "type": "input",
+                "block_id": f"block_id_{modifiable_field_name}",
+                "label": {
+                    "type": "plain_text",
+                    "text": modifiable_field_name
+                },
+                "element": {
+                    "type": "plain_text_input",
+                    "action_id": f"action_id_{modifiable_field_name}",
+                    "placeholder": {
                         "type": "plain_text",
-                        "text": modifiable_field_name
+                        "text": modifiable_field_value
                     },
-                    "element": {
-                        "type": "plain_text_input",
-                        "action_id": f"action_id_{modifiable_field_name}",
-                        "placeholder": {
-                            "type": "plain_text",
-                            "text": modifiable_field_value
-                        },
-                        "initial_value":modifiable_field_value,
-                        "multiline": False
-                    },
-                    "optional": True
-                }
+                    "initial_value": modifiable_field_value,
+                    "multiline": False
+                },
+                "optional": True
+            }
             blocks.append(field)
         return blocks
 
@@ -442,7 +439,3 @@ class SlackProvision:
                 modifiable_field_name = block_name.replace("block_id_", "")
                 if f"action_id_{modifiable_field_name}" in block_values:
                     self.inputs[modifiable_field_name] = block_values[f"action_id_{modifiable_field_name}"]["value"]
-        # self.reason = self.payload["view"]["state"]["values"]["block_id_{modifiable_field_name}"][
-        #     "action_id_{modifiable_field_name}"
-        # ]["value"]
-

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -122,9 +122,10 @@ class SlackProvision:
                 channel=self.approvers_channel,
                 ts=self.ts,
                 text="fallback",
-                blocks=blocks,
-                as_user=True
+                #blocks=blocks,
+                as_user=True,
             )
+            logger.info(response.status_code)
         except errors.SlackApiError as e:
             self.exception = e
             logger.error(e)

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -125,22 +125,22 @@ class SlackProvision:
             )
         try:
             slack_client = WebhookClient(self.response_url)
-            #response = slack_client.send(text="fallback", blocks=blocks)
-            #logger.info(response.status_code)
+            response = slack_client.send(text="fallback", blocks=blocks)
+            logger.info(response.status_code)
         except errors.SlackApiError as e:
             logger.error(e)
-        # try:
-        #     #slack_web_client = WebClient(self.token)
-        #     #response = slack_web_client.chat_update(
-        #     #     channel=self.requesters_channel,
-        #     #     ts=self.ts,
-        #     #     text="fallback",
-        #     #     blocks=blocks,
-        #     # )
-        #     #logger.info(response.status_code)
-        #     #return response.status_code
-        # except errors.SlackApiError as e:
-        #     logger.error(e)
+        try:
+            slack_web_client = WebClient(self.token)
+            response = slack_web_client.chat_update(
+                channel=self.requesters_channel,
+                ts=self.ts,
+                text="fallback",
+                blocks=blocks,
+            )
+            logger.info(response.status_code)
+            return response.status_code
+        except errors.SlackApiError as e:
+            logger.error(e)
         return 200
 
     def can_response(self):

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -65,11 +65,7 @@ class SlackProvision:
                 self.approved()
                 self.send_status_message(status="Approved")
             elif self.action_id == "Rejected":
-                if self.is_allowed():
-                    self.open_reject_reason_view()
-                else:
-                    self.rejected()
-
+                self.open_reject_reason_view()
             elif self.action_id == "Not allowed":
                 message = f"Same request/response user {self.user} not allowed. Prevent self approval is on."
                 self.open_dialog(title="Warning", message=message)

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -123,6 +123,7 @@ class SlackProvision:
                 ts=self.ts,
                 text="fallback",
                 blocks=blocks,
+                as_user=True
             )
         except errors.SlackApiError as e:
             self.exception = e

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -174,7 +174,6 @@ class SlackProvision:
         blocks.extend(get_header_block(name=self.name))
         blocks.extend(get_inputs_blocks(self.inputs))
 
-
         values = self.inputs.copy()
         values["requesters_ts"] = self.requesters_ts
         values["requesters_channel"] = self.requesters_channel

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -25,6 +25,7 @@ class SlackProvision:
         self.data = request.get_data()
         self.headers = request.headers
         self.payload = json.loads(request.form["payload"])
+        logger.info(self.payload)
         # Comes from the reject response modal view (data comes in private metadata)
         if self.is_callback_view(callback_id="reject_reason_modal"):
             # Some vars need to be defined so IDE dont complain
@@ -121,9 +122,9 @@ class SlackProvision:
             response = slack_web_client.chat_update(
                 channel=self.approvers_channel,
                 ts=self.ts,
-                #blocks=blocks,
+                blocks=blocks,
                 as_user=True,
-                text="Hola"
+                text=""
             )
             logger.info(response.status_code)
         except errors.SlackApiError as e:
@@ -149,8 +150,8 @@ class SlackProvision:
             response = slack_web_client.chat_update(
                 channel=self.requesters_channel,
                 ts=self.ts,
-                #blocks=blocks,
-                text="Hola"
+                blocks=blocks,
+                text=""
             )
         except errors.SlackApiError as e:
             self.exception = e

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -325,7 +325,7 @@ class SlackProvision:
 
         private_metadata = {
             "channel_id": self.payload["channel"]["id"],
-            "approvers_ts": self.payload["container"]["message_ts"],
+            "approvers_ts": self.payload["message"]["ts"],
             "requesters_ts": self.requesters_ts,
             "name": self.inputs["provision_class"],
             "inputs": self.inputs,

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -37,6 +37,7 @@ class SlackProvision:
         elif self.is_callback_view(callback_id="edit_view_modal"):
             self.channel_id = None
             self.reason = None
+            logger.info(self.payload)
             self.get_private_metadata()
             self.action_id = "Modified"
             self.get_modified_fields()

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -25,8 +25,6 @@ class SlackProvision:
             self.reject_with_reason()
             return
 
-        reason = payload['view']['state']['values']['reason_block']['reason_input']['value']
-
         action = payload["actions"][0]
         self.action_id = action["action_id"]
         self.inputs = json.loads(action["value"])

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -186,7 +186,7 @@ class SlackProvision:
             }
         try:
             client = WebClient(self.token)
-            client.views_open(
+            response = client.views_open(
                 trigger_id=self.payload['trigger_id'],
                 view={
                     "type": "modal",
@@ -216,6 +216,7 @@ class SlackProvision:
                     }
                 }
             )
+            logger.info(f"passed away {response}")
         except errors.SlackApiError as e:
             logger.error(e)
 

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -96,12 +96,12 @@ class SlackProvision:
                 message = f"Reason for rejection: {self.reason}"
                 # Message to approver same request message thread
                 self.send_message_to_thread(
-                    message=message, thread_ts=self.ts, channel=self.channel_id
+                    message=message, thread_ts=self.message_ts, channel=self.channel_id
                 )
                 # Message to requester same request message
                 self.send_message_to_thread(
                     message=message,
-                    thread_ts=self.message_ts,
+                    thread_ts=self.ts,
                     channel=self.requesters_channel,
                 )
                 # Update status on messages
@@ -113,7 +113,7 @@ class SlackProvision:
 
         except Exception as e:
             self.exception = e
-            logger.error(e)
+            logger.error(e, stack_info=True, exc_info=True)
 
     def send_message_approver(self, blocks):
         hide = self.inputs.get("hide")

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -233,7 +233,7 @@ class SlackProvision:
         reason = self.payload['view']['state']['values']['reason_block']['reject_reason_input']['value']
         self.action_id = f"Rejected with reason: {reason}"
         self.exception = None
-
+        return
         try:
             client = WebClient(self.token)
             client.chat_postMessage(
@@ -244,7 +244,7 @@ class SlackProvision:
         except errors.SlackApiError as e:
             logger.error(e)
 
-        self.send_status_message()
+        # self.send_status_message()
 
 
     def from_reject_response(self):

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -52,7 +52,7 @@ class SlackProvision:
         self.user = self.parse_user()
 
         self.name = self.inputs["provision_class"]
-        self.requesters_ts = self.inputs.pop("ts")
+        self.requesters_ts = self.inputs.pop("requesters_ts")
         self.approvers_ts = self.payload["container"]["message_ts"]
         self.requesters_channel = self.inputs.pop("requesters_channel")
         self.approvers_channel = self.inputs.pop("approvers_channel", None)
@@ -276,7 +276,7 @@ class SlackProvision:
     def get_private_metadata(self):
         metadata = json.loads(self.payload["view"]["private_metadata"])
         self.channel_id = metadata["channel_id"]
-        self.requesters_ts = metadata["reuqesters_ts"]
+        self.requesters_ts = metadata["requesters_ts"]
         self.message_ts = metadata["message_ts"]
         self.approvers_ts = metadata["message_ts"]
         self.inputs = metadata["inputs"]

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -228,7 +228,6 @@ class SlackProvision:
         self.user = " ".join(
             [s.capitalize() for s in self.user_payload["name"].split(".")]
         )
-        logger.info(self.user_payload)
         self.user_id = self.user_payload["id"]
 
     def get_private_metadata(self):
@@ -238,7 +237,6 @@ class SlackProvision:
         self.approvers_ts = metadata["approvers_ts"]
         self.inputs = metadata["inputs"]
         self.name = self.inputs["provision_class"]
-        self.user = metadata["user"]
         self.response_url = metadata["response_url"]
         self.requesters_channel = metadata["requesters_channel"]
         self.approvers_channel = metadata["approvers_channel"]
@@ -247,6 +245,10 @@ class SlackProvision:
         self.requester = metadata["requester"]
         self.prevent_self_approval = metadata["prevent_self_approval"]
         self.modifiables_fields = metadata["modifiables_fields"]
+        self.user_payload = metadata["user_payload"]
+        self.user = metadata["user"]
+        self.user_payload = metadata["user_payload"]
+        self.user_id = metadata["user_id"]
 
     def get_status_blocks(self, status):
         blocks = []
@@ -445,7 +447,9 @@ class SlackProvision:
             "approvers_ts": self.payload["message"]["ts"],
             "name": self.inputs["provision_class"],
             "inputs": self.inputs,
+            "user_payload": self.user_payload,
             "user": self.user,
+            "user_id": self.user_id,
             "response_url": self.response_url,
             "requesters_channel": self.requesters_channel,
             "token": self.token,

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -196,7 +196,8 @@ class SlackProvision:
         values["requesters_channel"] = self.requesters_channel
         values["approvers_channel"] = self.approvers_channel
         values["modifiables_fields"] = ";".join(list(self.modifiables_fields.keys()))
-        approvers_blocks.extend(get_buttons_blocks(value=json.dumps(values)))
+        edit_button = values["modifiables_fields"] is not None and values["modifiables_fields"] != ""
+        approvers_blocks.extend(get_buttons_blocks(value=json.dumps(values), edit_button=edit_button))
         asyncio.run(self.send_message_requester_approver(requesters_blocks, approvers_blocks))
         # self.send_message_requester(requesters_blocks)
         # self.send_message_approver(approvers_blocks)

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -207,6 +207,7 @@ class SlackProvision:
             slack_web_client = WebClient(self.token)
             user_info = slack_web_client.users_info(user=self.user_payload["id"])
             user_email = user_info["user"]["profile"]["email"]
+            logger.info(f"{user_email} <> {self.requester} <> {self.action_id}")
             if user_email == self.requester and self.action_id == "Approved":
                 return False
             else:

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -42,9 +42,9 @@ class SlackProvision:
             logger.info(self.payload)
             # self.action = self.payload["actions"][0]
             # self.inputs = json.loads(self.action["value"])
-            # self.get_private_metadata()
-            # self.action_id = "Modified"
-            # self.get_modified_fields()
+            self.get_private_metadata()
+            self.action_id = "Modified"
+            self.get_modified_fields()
             # self.send_modified_message()
             return
 
@@ -111,6 +111,7 @@ class SlackProvision:
                 self.open_edit_view()
             elif self.action_id == "Modified":
                 self.open_dialog("Modification", "Success")
+                #self.send_modified_message()
                 logger.info(f"Modified inputs = {self.inputs}")
 
         except Exception as e:

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -66,7 +66,7 @@ class SlackProvision:
                 self.is_open_reason_view()
             elif self.action_id == "Not allowed":
                 message = f"Same request/response user {self.user} not allowed. Prevent self approval is on."
-                self.send_message_to_thread(message=message, thread_ts=self.ts, channel=self.approvers_channel)
+                self.send_message_to_thread(message=message, thread_ts=self.ts, channel=self.response_url)
                 self.send_message_to_thread(message=message, thread_ts=self.ts, channel=self.requesters_channel)
             elif self.action_id == "Reject Response":
                 self.rejected()

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -74,7 +74,7 @@ class SlackProvision:
                 )
             elif self.action_id == "Reject Response":
                 self.rejected()
-                self.send_thread_message(message=self.reason, thread=self.channel_id)
+                self.send_thread_message(message=self.reason, thread=self.response_url)
                 self.send_thread_message(
                     message=self.reason, thread=self.requesters_channel
                 )
@@ -218,7 +218,8 @@ class SlackProvision:
         self.exception = None
 
     def get_base_blocks(self, status):
-        blocks = [
+        blocks = []
+        header_block = [
             {
                 "type": "header",
                 "text": {
@@ -226,8 +227,7 @@ class SlackProvision:
                     "text": self.name,
                     "emoji": True,
                 },
-            },
-            {"type": "divider"},
+            }
         ]
         input_blocks = [
             {
@@ -240,26 +240,29 @@ class SlackProvision:
             for key, value in self.inputs.items()
             if key != "provision_class"
         ]
-        blocks.extend(input_blocks)
-        blocks.append({"type": "divider"})
-        blocks.append(
-            {
+        status_block = {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
                     "text": f"*Status: {status} by {self.user}*",
-                },
+                }
             }
-        )
+
+        blocks.append(header_block)
+        blocks.append({"type": "divider"})
+        blocks.append(input_blocks)
+        blocks.append({"type": "divider"})
+        blocks.append(status_block)
+
         if self.exception:
-            blocks.append({"type": "divider"})
-            blocks.append(
-                {
+            exception_block = {
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
                         "text": f"Error while provisioning: {self.exception}",
                     },
                 }
-            )
+            blocks.append({"type": "divider"})
+            blocks.append(exception_block)
+
         return blocks

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -37,10 +37,10 @@ class SlackProvision:
             self.reason = None
             logger.info(self.payload)
             self.get_private_metadata()
-            self.action_id = ""
+            self.action_id = "Modified"
             self.get_modified_fields()
             logger.info(f"payload {self.payload}")
-            # self.send_modified_message()
+            #self.send_modified_message()
             return
 
         self.user_payload = self.payload["user"]
@@ -152,10 +152,7 @@ class SlackProvision:
         blocks = []
         blocks.extend(get_header_block(name=self.name))
         blocks.extend(get_inputs_blocks(inputs=self.inputs))
-        values = {"provision_class": self.name, "ts": self.ts, "requesters_channel": self.requesters_channel,
-                  "user": self.user, "requester": self.requester,
-                "prevent_self_approval": self.prevent_self_approval}
-
+        values = self.inputs
         self.send_message_requester(blocks)
         blocks.extend(get_buttons_blocks(value=json.dumps(values)))
         self.send_message_approver(blocks)

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -161,9 +161,9 @@ class SlackProvision:
         inputs.pop("ts", None)
         inputs.pop("requesters_channel", None)
         inputs.pop("approvers_channel", None)
-        self.inputs["requesters_ts"] = self.requesters_ts
-        self.inputs["requesters_channel"] = self.requesters_channel
-        self.inputs["approvers_channel"] = self.approvers_channel
+        # self.inputs["requesters_ts"] = self.requesters_ts
+        # self.inputs["requesters_channel"] = self.requesters_channel
+        # self.inputs["approvers_channel"] = self.approvers_channel
         values = self.inputs
         blocks = []
         blocks.extend(get_header_block(name=self.name))

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -383,7 +383,9 @@ class SlackProvision:
         return blocks
 
     def get_modifiable_fields(self):
-        modifiables_fields_names = self.modifiables_fields
+        if self.modifiables_fields is not None:
+            return self.modifiables_fields
+        modifiables_fields_names = self.inputs.pop("modifiables_fields","")
         fields = modifiables_fields_names.split(";")
         modifiables_fields = {}
         for field in fields:

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -320,7 +320,6 @@ class SlackProvision:
             modifiable_field_value,
         ) in self.modifiables_fields.items():
             if isinstance(modifiable_field_value, list):
-                blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": "Multi values"}})
                 for value in modifiable_field_value:
                     field = {
                         "type": "input",
@@ -339,7 +338,6 @@ class SlackProvision:
                         "optional": True,
                     }
                     blocks.append(field)
-                blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": "Modifiable fields"}})
                 continue
             field = {
                 "type": "input",

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -162,10 +162,11 @@ class SlackProvision:
     def send_not_allowed_message(self):
         try:
             client = WebClient(self.token)
-            client.chat_postMessage(
+            client.chat_update(
                 channel=self.requesters_channel,
-                thread_ts=self.ts,
-                text=f"User {self.user} not allowed to response (same user as requester). Prevent self approval activated.",
+                ts=self.ts,
+                text=f"User {self.user} not allowed to response (same user as requester). Prevent self approval "
+                     f"activated.",
             )
         except errors.SlackApiError as e:
             logger.error(e)

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -157,23 +157,25 @@ class SlackProvision:
             for field in hide:
                 self.inputs.pop(field, None)
             self.inputs.pop("hide")
-        blocks = []
-        blocks.extend(get_header_block(name=self.name))
         inputs = self.inputs.copy()
         inputs.pop("ts", None)
         inputs.pop("requesters_channel", None)
         inputs.pop("approvers_channel", None)
-        blocks.extend(get_inputs_blocks(inputs=self.inputs))
         self.inputs["requesters_ts"] = self.requesters_ts
         self.inputs["requesters_channel"] = self.requesters_channel
         self.inputs["approvers_channel"] = self.approvers_channel
         values = self.inputs
+        blocks = []
+        blocks.extend(get_header_block(name=self.name))
+        blocks.extend(get_inputs_blocks(self.inputs))
+        blocks.extend(get_status_block(status="Pending. Modified ", user=self.user))
         self.send_message_requester(
             blocks
-            + self.get_status_blocks(
-                status=f"Pending{' modified' if self.inputs.get('modified', False) else ''}"
-            )
         )
+
+        blocks = []
+        blocks.extend(get_header_block(name=self.name))
+        blocks.extend(get_inputs_blocks(self.inputs))
         blocks.extend(get_buttons_blocks(value=json.dumps(values)))
         self.send_message_approver(blocks)
 

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -199,8 +199,6 @@ class SlackProvision:
         edit_button = values.get("modifiables_fields", None) is not None and values["modifiables_fields"] != ""
         approvers_blocks.extend(get_buttons_blocks(value=json.dumps(values), edit_button=edit_button))
         asyncio.run(self.send_message_requester_approver(requesters_blocks, approvers_blocks))
-        # self.send_message_requester(requesters_blocks)
-        # self.send_message_approver(approvers_blocks)
 
     def is_allowed(self):
         if not self.prevent_self_approval:

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -59,7 +59,6 @@ class SlackProvision:
             Backward compatibility: prevent_self_approval deactivated """
         self.prevent_self_approval = self.inputs.get("prevent_self_approval", False)
         self.inputs["modified"] = self.inputs.get("modified", False)
-        logger.info(f"prevent_self_approval {self.prevent_self_approval}")
         if not self.is_allowed():
             self.action_id = "Not allowed"
 

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -370,7 +370,9 @@ class SlackProvision:
             "requesters_channel": self.requesters_channel,
             "token": self.token,
             "ts": self.ts,
-            "modifiables_fields": self.modifiables_fields
+            "modifiables_fields": self.modifiables_fields,
+            "requester": self.requester,
+            "approvers_channel": self.approvers_channel
         }
         try:
             modal_view = {

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -382,8 +382,8 @@ class SlackProvision:
         available_blocks = self.payload["view"]["state"]["values"]
         blocks = {block_name.replace("block_id_", ""): block_values for block_name, block_values in available_blocks.items() if "block_id_" in block_name}
         blocks = {block_name: block_values for block_name, block_values in
-                  blocks.items() if if f"action_id_{block_name}" in block_values}
-        for block_name, block_values in  blocks:
+                  blocks.items() if f"action_id_{block_name}" in block_values}
+        for block_name, block_values in blocks.items():
             actual_value = self.inputs[block_name]
             new_value = block_values[f"action_id_{block_name}"][
                 "value"

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -39,8 +39,10 @@ class SlackProvision:
             # self.action = self.payload["actions"][0]
             # self.inputs = json.loads(self.action["value"])
             self.get_private_metadata()
-            self.action_id = "Modified"
+            self.action_id = ""
             self.get_modified_fields()
+            logger.info(f"payload {self.payload}")
+            logger.info(f"data = {self.data}")
             # self.send_modified_message()
             return
 

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -381,12 +381,13 @@ class SlackProvision:
     def get_modified_fields(self):
         available_blocks = self.payload["view"]["state"]["values"]
         blocks = {block_name.replace("block_id_", ""): block_values for block_name, block_values in available_blocks.items() if "block_id_" in block_name}
+        blocks = {block_name: block_values for block_name, block_values in
+                  blocks.items() if if f"action_id_{block_name}" in block_values}
         for block_name, block_values in  blocks:
-            if f"action_id_{block_name}" in block_values:
-                actual_value = self.inputs[block_name]
-                new_value = block_values[f"action_id_{block_name}"][
-                    "value"
-                ]
-                if actual_value != new_value:
-                    self.inputs["modified"] = True
-                    self.inputs[block_name] = new_value
+            actual_value = self.inputs[block_name]
+            new_value = block_values[f"action_id_{block_name}"][
+                "value"
+            ]
+            if actual_value != new_value:
+                self.inputs["modified"] = True
+                self.inputs[block_name] = new_value

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -179,12 +179,10 @@ class SlackProvision:
             client = WebClient(self.token)
             client.chat_postMessage(
                 channel=self.channel_id,
-                thread_ts=self.ts,
                 text=f"Reason for rejection: {self.reason}",
             )
             client.chat_postMessage(
                 channel=self.requesters_channel,
-                thread_ts=self.message_ts,
                 text=f"Reason for rejection: {self.reason}",
             )
         except errors.SlackApiError as e:

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -320,62 +320,44 @@ class SlackProvision:
             modifiable_field_value,
         ) in self.modifiables_fields.items():
             if isinstance(modifiable_field_value, list):
-                elements = []
                 blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": "Multi values"}})
-                # field = {
-                #     "type": "input",
-                #     "block_id": f"block_id_{modifiable_field_name}",
-                #     "label": {"type": "plain_text", "text": modifiable_field_name},
-                #     "element": {
-                #         "type": "plain_text_input",
-                #         "action_id": f"action_id_{modifiable_field_name}",
-                #         "placeholder": {
-                #             "type": "plain_text",
-                #             "text": value,
-                #         },
-                #         "initial_value": value,
-                #         "multiline": False,
-                #     },
-                #     "optional": True,
-                # }
-                field = {
-                    "type": "actions",
-                    "block_id": f"block_id_{modifiable_field_name}",
-                    "label": {"type": "plain_text", "text": modifiable_field_name},
-                    "elements": elements,
-                    "optional": True,
-                }
                 for value in modifiable_field_value:
-                    elements.append({
+                    field = {
+                        "type": "input",
+                        "block_id": f"block_id_{modifiable_field_name}_{value}",
+                        "label": {"type": "plain_text", "text": modifiable_field_name},
+                        "element": {
                             "type": "plain_text_input",
-                            "action_id": f"action_id_{value}",
+                            "action_id": f"action_id_{modifiable_field_name}_{value}",
                             "placeholder": {
                                 "type": "plain_text",
                                 "text": value,
                             },
                             "initial_value": value,
                             "multiline": False,
-                        })
-                blocks.append(field)
+                        },
+                        "optional": True,
+                    }
+                    blocks.append(field)
                 blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": "Modifiable fields"}})
                 continue
-            # field = {
-            #     "type": "input",
-            #     "block_id": f"block_id_{modifiable_field_name}",
-            #     "label": {"type": "plain_text", "text": modifiable_field_name},
-            #     "element": {
-            #         "type": "plain_text_input",
-            #         "action_id": f"action_id_{modifiable_field_name}",
-            #         "placeholder": {
-            #             "type": "plain_text",
-            #             "text": modifiable_field_value,
-            #         },
-            #         "initial_value": modifiable_field_value,
-            #         "multiline": False,
-            #     },
-            #     "optional": True,
-            # }
-            # blocks.append(field)
+            field = {
+                "type": "input",
+                "block_id": f"block_id_{modifiable_field_name}",
+                "label": {"type": "plain_text", "text": modifiable_field_name},
+                "element": {
+                    "type": "plain_text_input",
+                    "action_id": f"action_id_{modifiable_field_name}",
+                    "placeholder": {
+                        "type": "plain_text",
+                        "text": modifiable_field_value,
+                    },
+                    "initial_value": modifiable_field_value,
+                    "multiline": False,
+                },
+                "optional": True,
+            }
+            blocks.append(field)
         return blocks
 
     def get_modifiable_fields(self):

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -199,7 +199,9 @@ class SlackProvision:
             "requesters_channel": self.requesters_channel,
             "token": self.token,
             "ts": self.ts,
-            "approvers_channel": self.approvers_channel
+            "approvers_channel": self.approvers_channel,
+            "requester": self.requester,
+            "prevent_self_approval": self.prevent_self_approval
         }
         try:
             client = WebClient(self.token)

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -18,6 +18,7 @@ class SlackProvision:
         self.payload = json.loads(request.form["payload"])
         if self.from_reject_response():
             logger.info(f"Reject response. Payload = {self.payload}")
+            self.reject_with_reason()
             # self.reject_with_reason()
             return
         self.user_payload = self.payload["user"]

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -81,12 +81,12 @@ class SlackProvision:
                 self.rejected()
                 message = f"reason for rejection: {self.reason}"
                 # Message to approver same request message thread
-                self.send_message_to_thread(
-                    message=message,
-                    thread_ts=self.approvers_ts,
-                    channel=self.channel_id,
-                    mention_requester=True
-                )
+                # self.send_message_to_thread(
+                #     message=message,
+                #     thread_ts=self.approvers_ts,
+                #     channel=self.channel_id,
+                #     mention_requester=True
+                # )
                 self.send_message_to_thread(
                     message=message,
                     thread_ts=self.requesters_ts,

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -339,7 +339,8 @@ class SlackProvision:
                         "action_id": f"input_{modifiable_field_name}",
                         "placeholder": {
                             "type": "plain_text",
-                            "text": modifiable_field_value
+                            "text": modifiable_field_value,
+                            "value": modifiable_field_value
                         },
                         "multiline": False
                     },

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -320,7 +320,26 @@ class SlackProvision:
             modifiable_field_value,
         ) in self.modifiables_fields.items():
             if isinstance(modifiable_field_value, list):
-                continue
+                blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": "Multi values"}})
+                for value in modifiable_field_value:
+                    field = {
+                        "type": "input",
+                        "block_id": f"block_id_{modifiable_field_name}",
+                        "label": {"type": "plain_text", "text": modifiable_field_name},
+                        "element": {
+                            "type": "plain_text_input",
+                            "action_id": f"action_id_{modifiable_field_name}",
+                            "placeholder": {
+                                "type": "plain_text",
+                                "text": value,
+                            },
+                            "initial_value": value,
+                            "multiline": False,
+                        },
+                        "optional": True,
+                    }
+                    blocks.append(field)
+                blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": "Modifiable fields"}})
             field = {
                 "type": "input",
                 "block_id": f"block_id_{modifiable_field_name}",

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -154,7 +154,7 @@ class SlackProvision:
         blocks = []
         blocks.extend(get_header_block(name=self.name))
         blocks.extend(get_inputs_blocks(inputs=self.inputs))
-        blocks.extend(get_buttons_blocks(value=self.inputs.copy()))
+        blocks.extend(get_buttons_blocks(value=json.dumps(self.inputs.copy())))
         self.send_message_approver(blocks)
         self.send_message_requester(blocks)
     def send_status_message(self, status):

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -61,7 +61,6 @@ class SlackProvision:
             elif self.action_id == "Rejected":
                 self.open_reject_reason_modal()
                 return 200
-                # self.rejected()
             elif self.action_id == "Not allowed":
                 self.send_not_allowed_message()
                 logger.info(f"Response not allowed for user {self.user}")
@@ -232,7 +231,6 @@ class SlackProvision:
         reason = self.payload['view']['state']['values']['reason_block']['reject_reason_input']['value']
         self.action_id = f"Rejected with reason: {reason}"
         self.exception = None
-        return
         try:
             client = WebClient(self.token)
             client.chat_postMessage(
@@ -243,7 +241,7 @@ class SlackProvision:
         except errors.SlackApiError as e:
             logger.error(e)
 
-        # self.send_status_message()
+        self.send_status_message()
 
 
     def from_reject_response(self):

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -166,7 +166,7 @@ class SlackProvision:
             )
         )
         blocks.extend(get_buttons_blocks(value=json.dumps(values)))
-        self.send_message_approver(blocks)
+        #self.send_message_approver(blocks)
 
     def send_status_message(self, status):
         hide = self.inputs.get("hide")

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -161,6 +161,7 @@ class SlackProvision:
         inputs.pop("ts", None)
         inputs.pop("requesters_channel", None)
         inputs.pop("approvers_channel", None)
+        inputs.pop("modifiables_fields", None)
         blocks = []
         blocks.extend(get_header_block(name=self.name))
         blocks.extend(get_inputs_blocks(self.inputs))

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -199,6 +199,7 @@ class SlackProvision:
             "requesters_channel": self.requesters_channel,
             "token": self.token,
             "ts": self.ts,
+            "approvers_channel": self.approvers_channel
         }
         try:
             client = WebClient(self.token)

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -67,7 +67,7 @@ class SlackProvision:
             self.action_id = "Not allowed"
 
     def __call__(self):
-        mention_requester = False
+        mention_requester = True
         try:
             if self.action_id == "Approved":
                 mention_requester = True

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -63,6 +63,8 @@ class SlackProvision:
                     view={
                         "type": "modal",
                         "callback_id": "reason_modal",
+                        "ts": self.ts,
+                        "requesters_channel":self.requesters_channel
                         "title": {
                             "type": "plain_text",
                             "text": "Denial Reason"

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -169,7 +169,7 @@ class SlackProvision:
             blocks
         )
 
-        blocks = []
+        blocks = []z
         blocks.extend(get_header_block(name=self.name))
         blocks.extend(get_inputs_blocks(self.inputs))
         self.inputs["requesters_ts"] = self.requesters_ts
@@ -383,8 +383,7 @@ class SlackProvision:
         return blocks
 
     def get_modifiable_fields(self):
-        if getattr(self, "modifiables_fields", None) is not None:
-            return self.modifiables_fields
+        logger.info(getattr(self, "modifiables_fields", "None"))
         modifiables_fields_names = self.inputs.pop("modifiables_fields","")
         fields = modifiables_fields_names.split(";")
         modifiables_fields = {}

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -17,10 +17,8 @@ class SlackProvision:
         self.headers = request.headers
         self.payload = json.loads(request.form["payload"])
         if self.from_reject_response():
-            return
-            # logger.info(f"Reject response. Payload = {self.payload}")
             self.reject_with_reason()
-            # return
+            return
         self.user_payload = self.payload["user"]
         self.action = self.payload["actions"][0]
         self.inputs = json.loads(self.action["value"])

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -50,10 +50,10 @@ class SlackProvision:
         self.user = self.parse_user()
 
         self.name = self.inputs["provision_class"]
-        self.requesters_ts = self.inputs.pop("requesters_ts")
+        self.requesters_ts = self.inputs.pop("requesters_ts", self.requesters_ts)
         self.approvers_ts = self.payload["container"]["message_ts"]
-        self.requesters_channel = self.inputs.pop("requesters_channel")
-        self.approvers_channel = self.inputs.pop("approvers_channel", None)
+        self.requesters_channel = self.inputs.pop("requesters_channel", self.requesters_channel)
+        self.approvers_channel = self.inputs.pop("approvers_channel", self.approvers_channel)
         self.requester = self.inputs.get("requester", "")
         self.modifiables_fields = self.get_modifiable_fields()
         """ Requester can response depending on flag for prevent self approval and user-requester values

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -39,6 +39,8 @@ class SlackProvision:
         elif self.is_callback_view(callback_id="edit_view_modal"):
             self.channel_id = None
             self.reason = None
+            self.action = self.payload["actions"][0]
+            self.inputs = json.loads(self.action["value"])
             self.get_private_metadata()
             self.action_id = "Modified"
             self.get_modified_fields()

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -17,6 +17,8 @@ class SlackProvision:
         self.headers = request.headers
         self.payload = json.loads(request.form["payload"])
         if self.from_reject_response():
+            self.name = "Provision Testing"
+            self.action_id = ""
             return
         self.user_payload = self.payload["user"]
         self.action = self.payload["actions"][0]
@@ -241,7 +243,7 @@ class SlackProvision:
         except errors.SlackApiError as e:
             logger.error(e)
 
-        self.send_status_message()
+        # self.send_status_message()
 
 
     def from_reject_response(self):

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -158,7 +158,7 @@ class SlackProvision:
         blocks.extend(get_inputs_blocks(inputs=self.inputs))
         blocks.extend(get_buttons_blocks(value=json.dumps(self.inputs.copy())))
         self.send_message_approver(blocks)
-        self.send_message_requester(blocks)
+        # self.send_message_requester(blocks)
     def send_status_message(self, status):
         hide = self.inputs.get("hide")
         if hide:

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -343,6 +343,7 @@ class SlackProvision:
                             "type": "plain_text",
                             "text": modifiable_field_value
                         },
+                        "initial_value":modifiable_field_value,
                         "multiline": False
                     },
                     "optional": True

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -16,6 +16,14 @@ class SlackProvision:
         self.data = request.get_data()
         self.headers = request.headers
         self.payload = json.loads(request.form["payload"])
+        logger.info(self.payload)
+        return
+        self.requesters_channel = self.inputs.pop("requesters_channel")
+        return
+        if self.from_reject_response():
+            self.reject_with_reason()
+            return
+
         self.user_payload = self.payload["user"]
         self.action = self.payload["actions"][0]
         self.inputs = json.loads(self.action["value"])
@@ -23,12 +31,6 @@ class SlackProvision:
         self.response_url = self.payload["response_url"]
         self.action_id = self.action["action_id"]
         self.ts = self.inputs.pop("ts")
-        self.requesters_channel = self.inputs.pop("requesters_channel")
-        logger.info(self.payload)
-        return
-        if self.from_reject_response():
-            self.reject_with_reason()
-            return
 
         self.approvers_channel = self.inputs.pop("approvers_channel", None)
         self.user = " ".join(

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -221,7 +221,7 @@ class SlackProvision:
         logger.info("reject_with_reason")
         metadata = json.loads(self.payload['view']['private_metadata'])
         channel_id = metadata["channel_id"]
-        ts = metadata["message_ts"]
+        self.ts = metadata["message_ts"]
         self.inputs = metadata["inputs"]
         self.name = self.inputs["provision_class"]
         self.user = metadata["user"]
@@ -229,7 +229,7 @@ class SlackProvision:
         self.requesters_channel = metadata["requesters_channel"]
         self.token = metadata["token"]
         reason = self.payload['view']['state']['values']['reason_block']['reject_reason_input']['value']
-        self.action_id = "Rejected with reason"
+        self.action_id = f"Rejected with reason: {reason}"
         self.exception = None
 
         try:

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -77,7 +77,7 @@ class SlackProvision:
                 return
             elif self.action_id == "Reject Response":
                 self.rejected()
-                message = f"<@{self.user_id}> Reason for rejection: {self.reason}"
+                message = f"<@{self.user_id}> reason for rejection: {self.reason}"
                 # Message to approver same request message thread
                 self.send_message_to_thread(
                     message=message,
@@ -151,13 +151,13 @@ class SlackProvision:
             self.exception = e
             logger.error(e, stack_info=True, exc_info=True)
 
-    def send_status_message(self, status):
+    def send_status_message(self, status, mention_requester=False):
         hide = self.inputs.get("hide")
         if hide:
             for field in hide:
                 self.inputs.pop(field, None)
             self.inputs.pop("hide")
-        blocks = self.get_status_blocks(status)
+        blocks = self.get_message_status(status, mention_requester)
         self.send_message_approver(blocks)
         self.send_message_requester(blocks)
 
@@ -250,11 +250,11 @@ class SlackProvision:
         self.user_payload = metadata["user_payload"]
         self.user_id = metadata["user_id"]
 
-    def get_status_blocks(self, status):
+    def get_message_status(self, status, mention_requester=False):
         blocks = []
         blocks.extend(get_header_block(name=self.name))
         blocks.extend(get_inputs_blocks(self.inputs))
-        blocks.extend(get_status_block(status=status, user=self.user))
+        blocks.extend(get_status_block(status=status, user=self.user, mention_requester=mention_requester, user_id=self.user_id))
         if self.exception:
             blocks.extend(get_exception_block(self.exception))
 

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -155,7 +155,7 @@ class SlackProvision:
         blocks.extend(get_inputs_blocks(inputs=self.inputs))
         values = {"provision_class": self.name, "ts": self.ts, "requesters_channel": self.requesters_channel,
                   "user": self.user, "requester": self.requester,
-                  "modifiables_fields": self.modifiables_fields, "prevent_self_approval": self.prevent_self_approval}
+                "prevent_self_approval": self.prevent_self_approval}
 
         self.send_message_requester(blocks)
         blocks.extend(get_buttons_blocks(value=json.dumps(values)))
@@ -287,6 +287,7 @@ class SlackProvision:
         self.exception = None
         self.requester = metadata["requester"]
 
+
     def get_status_blocks(self, status):
         blocks = []
 
@@ -373,7 +374,8 @@ class SlackProvision:
             "ts": self.ts,
             "modifiables_fields": self.modifiables_fields,
             "requester": self.requester,
-            "approvers_channel": self.approvers_channel
+            "approvers_channel": self.approvers_channel,
+            "prevent_self_approval": self.prevent_self_approval
         }
         try:
             modal_view = {

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -42,7 +42,7 @@ class SlackProvision:
             self.get_private_metadata()
             self.action_id = "Modified"
             self.get_modified_fields()
-            self.send_status_message(status="Pending (modified) ")
+            self.send_modified_message()
             return
 
         self.user_payload = self.payload["user"]
@@ -142,7 +142,7 @@ class SlackProvision:
         except errors.SlackApiError as e:
             self.exception = e
             logger.error(e)
-    
+
     def send_modified_message(self):
         hide = self.inputs.get("hide")
         if hide:

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -209,7 +209,6 @@ class SlackProvision:
 
     def reject_with_reason(self):
         logger.info("reject_with_reason")
-        return
         try:
             metadata = json.loads(self.payload['view']['private_metadata'])
             channel_id = metadata["channel_id"]
@@ -224,6 +223,7 @@ class SlackProvision:
         except errors.SlackApiError as e:
             logger.error(e)
         self.action_id = "Rejected with reason"
+        self.send_status_message()
         self.rejected()
 
     def from_reject_response(self):

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -323,11 +323,11 @@ class SlackProvision:
                 for value in modifiable_field_value:
                     field = {
                         "type": "input",
-                        "block_id": f"block_id_{modifiable_field_name}_{value}",
+                        "block_id": f"block_id_{modifiable_field_name}",
                         "label": {"type": "plain_text", "text": modifiable_field_name},
                         "element": {
                             "type": "plain_text_input",
-                            "action_id": f"action_id_{modifiable_field_name}_{value}",
+                            "action_id": f"action_id_{modifiable_field_name}",
                             "placeholder": {
                                 "type": "plain_text",
                                 "text": value,

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -169,13 +169,13 @@ class SlackProvision:
             blocks
         )
 
-        self.inputs["requesters_ts"] = self.requesters_ts
-        self.inputs["requesters_channel"] = self.requesters_channel
-        self.inputs["approvers_channel"] = self.approvers_channel
-        values = self.inputs
         blocks = []
         blocks.extend(get_header_block(name=self.name))
         blocks.extend(get_inputs_blocks(self.inputs))
+        self.inputs["requesters_ts"] = self.requesters_ts
+        self.inputs["requesters_channel"] = self.requesters_channel
+        self.inputs["approvers_channel"] = self.approvers_channel
+        values = self.inputs.copy()
         blocks.extend(get_buttons_blocks(value=json.dumps(values)))
         self.send_message_approver(blocks)
 

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -154,6 +154,9 @@ class SlackProvision:
         blocks = []
         blocks.extend(get_header_block(name=self.name))
         blocks.extend(get_inputs_blocks(inputs=self.inputs))
+        self.inputs["ts"] = self.ts
+        self.inputs["requesters_channel"] = self.requesters_channel
+        self.inputs["approvers_channel"] = self.approvers_channel
         values = self.inputs
         self.send_message_requester(blocks)
         blocks.extend(get_buttons_blocks(value=json.dumps(values)))

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -405,6 +405,8 @@ class SlackProvision:
 
         for block_name, block_values in blocks.items():
             new_value = block_values[f"action_id_{block_name}"]["value"]
+            if new_value == "":
+                continue
             self.inputs["modified"] = True
             self.inputs[re.sub(r"_\d+$", '', block_name)].append(new_value)
 

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -335,6 +335,7 @@ class SlackProvision:
             if isinstance(modifiable_field_value, list):
                 item_number = 0
                 for value in modifiable_field_value:
+                    value = value if value != "" else "no value",
                     field = {
                         "type": "input",
                         "block_id": f"multivalue_block_id_{modifiable_field_name}_{item_number}",
@@ -346,7 +347,7 @@ class SlackProvision:
                                 "type": "plain_text",
                                 "text": value,
                             },
-                            "initial_value": value if value != "" else "no value",
+                            "initial_value": value,
                             "multiline": False,
                         },
                         "optional": True,

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -149,7 +149,8 @@ class SlackProvision:
             response = slack_web_client.chat_update(
                 channel=self.requesters_channel,
                 ts=self.ts,
-                blocks=blocks,
+                #blocks=blocks,
+                text="Hola"
             )
         except errors.SlackApiError as e:
             self.exception = e

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -173,12 +173,13 @@ class SlackProvision:
         blocks = []
         blocks.extend(get_header_block(name=self.name))
         blocks.extend(get_inputs_blocks(self.inputs))
-        self.inputs["requesters_ts"] = self.requesters_ts
-        self.inputs["requesters_channel"] = self.requesters_channel
-        self.inputs["approvers_channel"] = self.approvers_channel
-        self.inputs["modifiables_fields"] = ";".join(list(self.modifiables_fields.keys()))
+
 
         values = self.inputs.copy()
+        values["requesters_ts"] = self.requesters_ts
+        values["requesters_channel"] = self.requesters_channel
+        values["approvers_channel"] = self.approvers_channel
+        values["modifiables_fields"] = ";".join(list(self.modifiables_fields.keys()))
         blocks.extend(get_buttons_blocks(value=json.dumps(values)))
         self.send_message_approver(blocks)
 

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -323,11 +323,11 @@ class SlackProvision:
                 for value in modifiable_field_value:
                     field = {
                         "type": "input",
-                        "block_id": f"block_id_{modifiable_field_name}",
+                        "block_id": f"multivalue_block_id_{modifiable_field_name}_{value}",
                         "label": {"type": "plain_text", "text": modifiable_field_name},
                         "element": {
                             "type": "plain_text_input",
-                            "action_id": f"action_id_{modifiable_field_name}",
+                            "action_id": f"multivalue_action_id_{modifiable_field_name}_{value}",
                             "placeholder": {
                                 "type": "plain_text",
                                 "text": value,
@@ -385,6 +385,27 @@ class SlackProvision:
             if actual_value != new_value:
                 self.inputs["modified"] = True
                 self.inputs[block_name] = new_value
+
+        blocks = {
+            block_name.replace("multivalue_block_id_", ""): block_values
+            for block_name, block_values in available_blocks.items()
+            if "multivalue_block_id_" in block_name
+        }
+
+        for block_name, block_values in blocks.items():
+            self.inputs[block_name] = []
+
+        blocks = {
+            block_name: block_values
+            for block_name, block_values in blocks.items()
+            if f"multivalue_action_id_{block_name}" in block_values
+        }
+
+        for block_name, block_values in blocks.items():
+            new_value = block_values[f"multivalue_action_id_{block_name}"]["value"]
+            self.inputs["modified"] = True
+            self.inputs[block_name].append(new_value)
+
 
     @staticmethod
     def construct_reason_modal(private_metadata):

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -125,22 +125,22 @@ class SlackProvision:
             )
         try:
             slack_client = WebhookClient(self.response_url)
-            response = slack_client.send(text="fallback", blocks=blocks)
-            logger.info(response.status_code)
+            #response = slack_client.send(text="fallback", blocks=blocks)
+            #logger.info(response.status_code)
         except errors.SlackApiError as e:
             logger.error(e)
-        try:
-            slack_web_client = WebClient(self.token)
-            response = slack_web_client.chat_update(
-                channel=self.requesters_channel,
-                ts=self.ts,
-                text="fallback",
-                blocks=blocks,
-            )
-            logger.info(response.status_code)
-            return response.status_code
-        except errors.SlackApiError as e:
-            logger.error(e)
+        # try:
+        #     #slack_web_client = WebClient(self.token)
+        #     #response = slack_web_client.chat_update(
+        #     #     channel=self.requesters_channel,
+        #     #     ts=self.ts,
+        #     #     text="fallback",
+        #     #     blocks=blocks,
+        #     # )
+        #     #logger.info(response.status_code)
+        #     #return response.status_code
+        # except errors.SlackApiError as e:
+        #     logger.error(e)
         return 200
 
     def can_response(self):

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -96,9 +96,11 @@ class SlackProvision:
                 # Update status on messages
                 self.send_status_message(status="Rejected")
             elif self.action_id == "Edit":
+                logger.info(f"Initial inputs = {self.inputs}")
                 self.open_edit_view()
             elif self.action_id == "Modified":
-                self.open_dialog("Modified", "Success")
+                self.open_dialog("Modification", "Success")
+                logger.info(f"Modified inputs = {self.inputs}")
 
         except Exception as e:
             self.exception = e
@@ -371,9 +373,13 @@ class SlackProvision:
         return modifiables_fields
 
     def get_modified_fields(self):
-
+        available_blocks = self.payload["view"]["state"]["values"]
+        for block_name, block_values in available_blocks.items():
+            if "block_id_" in block_name:
+                modifiable_field_name = block_name.replace("block_id_", "")
+                if f"action_id_{modifiable_field_name}" in block_values:
+                    self.inputs[modifiable_field_name] = block_values[f"action_id_{modifiable_field_name}"]["value"]
         # self.reason = self.payload["view"]["state"]["values"]["block_id_{modifiable_field_name}"][
         #     "action_id_{modifiable_field_name}"
         # ]["value"]
-        return self.inputs
 

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -75,6 +75,7 @@ class SlackProvision:
                 self.send_message_to_thread(message=message, thread_ts=self.ts, channel=self.channel_id)
                 # Message to requester same request message
                 self.send_message_to_thread(message=message, thread_ts=self.message_ts, channel=self.requesters_channel)
+                # Update status on messages
                 self.send_status_message(status="Rejected")
 
         except Exception as e:
@@ -119,19 +120,6 @@ class SlackProvision:
                 return False
             else:
                 return True
-        except errors.SlackApiError as e:
-            logger.error(e)
-
-    def send_not_allowed_message(self):
-        blocks = self.get_base_blocks()
-        try:
-            client = WebClient(self.token)
-            client.chat_update(
-                channel=self.requesters_channel,
-                ts=self.ts,
-                text="fallback",
-                blocks=blocks
-            )
         except errors.SlackApiError as e:
             logger.error(e)
 

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -65,7 +65,7 @@ class SlackProvision:
                 return
             elif self.action_id == "Not allowed":
                 message = f"Prevent self approval is on. Not allowed for same user {self.user}"
-                self.send_message_to_thread(message=message, thread_ts=self.message_ts, channel=self.requesters_channel)
+                self.send_message_to_thread(message=message, thread_ts=self.ts, channel=self.requesters_channel)
                 # self.send_not_allowed_message()
                 return
             elif self.action_id == "Reject Response":

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -71,6 +71,9 @@ class SlackProvision:
                 self.send_not_allowed_message()
                 logger.info(f"Response not allowed for user {self.user}")
                 return
+            elif self.action_id == "Rejected with reason":
+                logger.info(f"Rejected with reason by {self.user}")
+                return
 
         except Exception as e:
             self.exception = e
@@ -217,6 +220,7 @@ class SlackProvision:
             )
         except errors.SlackApiError as e:
             logger.error(e)
+        self.action_id = "Rejected with reason"
         self.rejected()
 
     def from_reject_response(self):

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -198,6 +198,7 @@ class SlackProvision:
             slack_web_client = WebClient(self.token)
             user_info = slack_web_client.users_info(user=self.user_payload["id"])
             user_email = user_info["user"]["profile"]["email"]
+            logger.info(f"user_email={user_email}, requester={self.requester}")
             if user_email == self.requester and self.action_id == "Approved":
                 return False
             else:

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -18,7 +18,7 @@ class SlackProvision:
         self.payload = json.loads(request.form["payload"])
         self.user_payload = self.payload["user"]
         logger.info(self.payload)
-
+        return
         if self.from_reject_response():
             self.reject_with_reason()
             return

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -87,11 +87,7 @@ class SlackProvision:
             logger.error(e)
 
     def send_status_message(self, requester_status=None, approver_status=None):
-        hide = self.inputs.get("hide")
-        if hide:
-            for field in hide:
-                self.inputs.pop(field, None)
-            self.inputs.pop("hide")
+
         blocks = self.get_base_blocks(status=approver_status)
         try:
             # Message for approver
@@ -99,7 +95,7 @@ class SlackProvision:
             response = slack_client.send(text="fallback", blocks=blocks)
             logger.info(f"Message sent to response_url {self.response_url} status code {response.status_code}")
         except errors.SlackApiError as e:
-            logger.error(f"Error sending status message to {self.response_url} error: {e}")
+            logger.error(f"Error sending status message to response_url {self.response_url} error: {e}")
         try:
             # Message for requester
             blocks = self.get_base_blocks(status=requester_status)
@@ -112,7 +108,13 @@ class SlackProvision:
             )
             logger.info(f"Message sent to requesters channel {self.requesters_channel} status code {response.status_code}")
         except errors.SlackApiError as e:
-            logger.error(f"Error sending status message to {self.requesters_channel} error: {e}")
+            logger.error(f"Error sending status message to requesters_channel {self.requesters_channel} error: {e}")
+
+        hide = self.inputs.get("hide")
+        if hide:
+            for field in hide:
+                self.inputs.pop(field, None)
+            self.inputs.pop("hide")
 
     def is_allowed(self):
         if not self.prevent_self_approval:

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -319,6 +319,8 @@ class SlackProvision:
             modifiable_field_name,
             modifiable_field_value,
         ) in self.modifiables_fields.items():
+            if isinstance(modifiable_field_value, list):
+                continue
             field = {
                 "type": "input",
                 "block_id": f"block_id_{modifiable_field_name}",

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -383,7 +383,7 @@ class SlackProvision:
         return blocks
 
     def get_modifiable_fields(self):
-        modifiables_fields_names = self.inputs.pop("modifiables_fields", "")
+        modifiables_fields_names = self.modifiables_fields
         fields = modifiables_fields_names.split(";")
         modifiables_fields = {}
         for field in fields:

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -18,7 +18,7 @@ class SlackProvision:
         self.headers = request.headers
         self.payload = json.loads(request.form["payload"])
 
-        # Comes from the reject response modal view (data comes in private metadata)
+        # Come from the reject response modal view (data comes in private metadata)
         if self.is_reject_reason_view():
             self.channel_id = None
             self.reason = None
@@ -49,10 +49,12 @@ class SlackProvision:
         verifier = SignatureVerifier(signing_secret)
         return verifier.is_valid(self.data, timestamp, signature)
 
-    def approved(self):
+    @staticmethod
+    def approved():
         logger.info("request approved")
 
-    def rejected(self):
+    @staticmethod
+    def rejected():
         logger.info("request rejected")
 
     def __call__(self):
@@ -72,7 +74,7 @@ class SlackProvision:
                 self.send_message_to_thread(message=message, thread_ts=self.ts, channel=self.channel_id)
                 # Message to requester same request message
                 self.send_message_to_thread(message=message, thread_ts=self.message_ts, channel=self.requesters_channel)
-                self.send_status_message(status="Approved")
+                self.send_status_message(status="Rejected")
 
         except Exception as e:
             self.exception = e

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -347,6 +347,7 @@ class SlackProvision:
                         "optional": True,
                     }
                     blocks.append(field)
+                    blocks.append({"type": "divider"})
                     continue
                 for valid_value in modifiable_field_value:
                     valid_value = valid_value if valid_value != "" and valid_value is not None else "no value"
@@ -368,6 +369,7 @@ class SlackProvision:
                     }
                     blocks.append(field)
                     item_number += 1
+                blocks.append({"type": "divider"})
                 continue
             valid_value = modifiable_field_value if modifiable_field_value != "" and modifiable_field_value is not None else "no value"
 
@@ -388,6 +390,7 @@ class SlackProvision:
                 "optional": True,
             }
             blocks.append(field)
+            blocks.append({"type": "divider"})
         return blocks
 
     def get_modifiable_fields(self):

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -17,7 +17,7 @@ class SlackProvision:
         self.headers = request.headers
         self.payload = json.loads(request.form["payload"])
         if self.from_reject_response():
-            return 200
+            return
             # logger.info(f"Reject response. Payload = {self.payload}")
             self.reject_with_reason()
             # return
@@ -62,12 +62,12 @@ class SlackProvision:
                 self.approved()
             elif self.action_id == "Rejected":
                 self.open_reject_reason_modal()
-                return
+                return 200
                 # self.rejected()
             elif self.action_id == "Not allowed":
                 self.send_not_allowed_message()
                 logger.info(f"Response not allowed for user {self.user}")
-                return
+                return 200
             else:
                 logger.info(f"Action not found called by {self.user}")
                 return 200
@@ -82,6 +82,7 @@ class SlackProvision:
                 self.inputs.pop(field, None)
             self.inputs.pop("hide")
         self.send_status_message()
+        return 200
 
     def send_status_message(self):
         blocks = [

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -65,7 +65,11 @@ class SlackProvision:
                 self.approved()
                 self.send_status_message(status="Approved")
             elif self.action_id == "Rejected":
-                self.open_reject_reason_view()
+                if self.is_allowed():
+                    self.open_reject_reason_view()
+                else:
+                    self.rejected()
+
             elif self.action_id == "Not allowed":
                 message = f"Same request/response user {self.user} not allowed. Prevent self approval is on."
                 self.open_dialog(title="Warning", message=message)

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -70,7 +70,7 @@ class SlackProvision:
                 return
             else:
                 logger.info(f"Action not found called by {self.user}")
-                return
+                return 200
 
         except Exception as e:
             self.exception = e

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -84,8 +84,6 @@ class SlackProvision:
                 message = f"reason for rejection: {self.reason}"
                 asyncio.run(self.send_notifications(message=message, mention_requester=True))
 
-
-
             elif self.action_id == "Edit":
                 self.open_edit_view()
                 return
@@ -341,7 +339,7 @@ class SlackProvision:
                             "action_id": f"action_id_{modifiable_field_name}_{item_number}",
                             "placeholder": {
                                 "type": "plain_text",
-                                "text": "Insert value",
+                                "text": "Insert value (empty to remove)",
                             },
                             "initial_value": "no value",
                             "multiline": False,
@@ -361,7 +359,7 @@ class SlackProvision:
                             "action_id": f"action_id_{modifiable_field_name}_{item_number}",
                             "placeholder": {
                                 "type": "plain_text",
-                                "text": "Insert value",
+                                "text": "Insert value (empty to remove)",
                             },
                             "initial_value": value,
                             "multiline": False,
@@ -371,6 +369,8 @@ class SlackProvision:
                     blocks.append(field)
                     item_number += 1
                 continue
+            value = modifiable_field_value if modifiable_field_value != "" else "no value"
+
             field = {
                 "type": "input",
                 "block_id": f"block_id_{modifiable_field_name}",
@@ -380,9 +380,9 @@ class SlackProvision:
                     "action_id": f"action_id_{modifiable_field_name}",
                     "placeholder": {
                         "type": "plain_text",
-                        "text": "Insert value",
+                        "text": "Insert value (empty to remove)",
                     },
-                    "initial_value": modifiable_field_value,
+                    "initial_value": value,
                     "multiline": False,
                 },
                 "optional": True,

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -233,6 +233,7 @@ class SlackProvision:
         reason = self.payload['view']['state']['values']['reason_block']['reject_reason_input']['value']
         self.action_id = f"Rejected with reason: {reason}"
         self.exception = None
+        return
         try:
             client = WebClient(self.token)
             client.chat_postMessage(

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -266,6 +266,7 @@ class SlackProvision:
 
     def get_private_metadata(self):
         metadata = json.loads(self.payload["view"]["private_metadata"])
+        logger.info(f"private metadata {metadata}")
         self.channel_id = metadata["channel_id"]
         self.ts = metadata["ts"]
         self.message_ts = metadata["message_ts"]

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -73,7 +73,7 @@ class SlackProvision:
                                 "block_id": "reason_block",
                                 "label": {
                                     "type": "plain_text",
-                                    "text": "Please provide a reason for denial:"
+                                    "text": "Please provide a reason for deny:"
                                 },
                                 "element": {
                                     "type": "plain_text_input",

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -194,7 +194,7 @@ class SlackProvision:
         try:
             client = WebClient(self.token)
             response = client.views_open(
-                trigger_id=self.payload['trigger_id'],
+                trigger_id="1",
                 view={
                     "type": "modal",
                     "callback_id": "reject_reason_modal",

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -340,6 +340,7 @@ class SlackProvision:
                     }
                     blocks.append(field)
                 blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": "Modifiable fields"}})
+                continue
             field = {
                 "type": "input",
                 "block_id": f"block_id_{modifiable_field_name}",

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -320,25 +320,43 @@ class SlackProvision:
             modifiable_field_value,
         ) in self.modifiables_fields.items():
             if isinstance(modifiable_field_value, list):
+                elements = []
                 blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": "Multi values"}})
+                # field = {
+                #     "type": "input",
+                #     "block_id": f"block_id_{modifiable_field_name}",
+                #     "label": {"type": "plain_text", "text": modifiable_field_name},
+                #     "element": {
+                #         "type": "plain_text_input",
+                #         "action_id": f"action_id_{modifiable_field_name}",
+                #         "placeholder": {
+                #             "type": "plain_text",
+                #             "text": value,
+                #         },
+                #         "initial_value": value,
+                #         "multiline": False,
+                #     },
+                #     "optional": True,
+                # }
+                field = {
+                    "type": "input",
+                    "block_id": f"block_id_{modifiable_field_name}",
+                    "label": {"type": "plain_text", "text": modifiable_field_name},
+                    "elements": elements,
+                    "optional": True,
+                }
                 for value in modifiable_field_value:
-                    field = {
-                        "type": "input",
-                        "block_id": f"block_id_{modifiable_field_name}",
-                        "label": {"type": "plain_text", "text": modifiable_field_name},
-                        "element": {
+                    elements.append({
                             "type": "plain_text_input",
-                            "action_id": f"action_id_{modifiable_field_name}",
+                            "action_id": f"action_id_{value}",
                             "placeholder": {
                                 "type": "plain_text",
                                 "text": value,
                             },
                             "initial_value": value,
                             "multiline": False,
-                        },
-                        "optional": True,
-                    }
-                    blocks.append(field)
+                        })
+                blocks.append(field)
                 blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": "Modifiable fields"}})
                 continue
             field = {

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -302,18 +302,20 @@ class SlackProvision:
             "modifiables_fields": self.modifiables_fields
         }
         try:
-            client = WebClient(self.token)
-            client.views_open(
-                trigger_id=self.payload["trigger_id"],
-                view={
+            modal_view = {
                     "type": "modal",
                     "callback_id": "reject_reason_modal",
                     "private_metadata": json.dumps(private_metadata),
                     "title": {"type": "plain_text", "text": "Edit view"},
                     "blocks": self.construct_modifiable_fields_blocks(),
                     "submit": {"type": "plain_text", "text": "Save"},
-                },
+                }
+            client = WebClient(self.token)
+            client.views_open(
+                trigger_id=self.payload["trigger_id"],
+                view=modal_view
             )
+            logger.info(f"modal view =   {modal_view}")
         except errors.SlackApiError as e:
             self.exception = e
             logger.error(e)
@@ -339,15 +341,13 @@ class SlackProvision:
                         "action_id": f"input_{modifiable_field_name}",
                         "placeholder": {
                             "type": "plain_text",
-                            "text": modifiable_field_value,
-                            "value": modifiable_field_value
+                            "text": modifiable_field_value
                         },
                         "multiline": False
                     },
                     "optional": True
                 }
             blocks.append(field)
-        logger.info(f"blocks={blocks}")
         return blocks
 
     def capture_modifiable_fields(self):

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -97,9 +97,9 @@ class SlackProvision:
             # Message for approver
             slack_client = WebhookClient(self.response_url)
             response = slack_client.send(text="fallback", blocks=blocks)
-            logger.info(response.status_code)
+            logger.info(f"Message sent to response_url {self.response_url} status code {response.status_code}")
         except errors.SlackApiError as e:
-            logger.error(e)
+            logger.error(f"Error sending status message to {self.response_url} error: {e}")
         try:
             # Message for requester
             blocks = self.get_base_blocks(status=requester_status)
@@ -110,9 +110,9 @@ class SlackProvision:
                 text="fallback",
                 blocks=blocks,
             )
-            logger.info(response.status_code)
+            logger.info(f"Message sent to requesters channel {self.requesters_channel} status code {response.status_code}")
         except errors.SlackApiError as e:
-            logger.error(e)
+            logger.error(f"Error sending status message to {self.requesters_channel} error: {e}")
 
     def is_allowed(self):
         if not self.prevent_self_approval:

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -288,6 +288,7 @@ class SlackProvision:
         self.exception = None
         self.requester = metadata["requester"]
         self.prevent_self_approval = metadata["prevent_self_approval"]
+        self.modifiables_fields = metadata["modifiables_fields"]
 
     def get_status_blocks(self, status):
         blocks = []
@@ -337,6 +338,7 @@ class SlackProvision:
             "approvers_channel": self.approvers_channel,
             "requester": self.requester,
             "prevent_self_approval": self.prevent_self_approval,
+            "modifiables_fields": self.modifiables_fields
         }
         try:
             modal_view = {
@@ -381,7 +383,7 @@ class SlackProvision:
         return blocks
 
     def get_modifiable_fields(self):
-        modifiables_fields_names = self.inputs.get("modifiables_fields", "")
+        modifiables_fields_names = self.inputs.pop("modifiables_fields", "")
         fields = modifiables_fields_names.split(";")
         modifiables_fields = {}
         for field in fields:

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -66,7 +66,7 @@ class SlackProvision:
                 self.is_open_reason_view()
             elif self.action_id == "Not allowed":
                 message = f"Same request/response user {self.user} not allowed. Prevent self approval is on."
-                self.send_message_to_thread(message=message, thread_ts=self.ts, channel=self.response_url)
+                self.send_message_to_thread(message=message, thread_ts=self.ts, channel=self.approvers_channel)
                 self.send_message_to_thread(message=message, thread_ts=self.ts, channel=self.requesters_channel)
             elif self.action_id == "Reject Response":
                 self.rejected()

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -157,6 +157,10 @@ class SlackProvision:
             self.inputs.pop("hide")
         blocks = []
         blocks.extend(get_header_block(name=self.name))
+        inputs = self.inputs.copy()
+        inputs.pop("ts")
+        inputs.pop("requesters_channel")
+        inputs.pop("approvers_channel")
         blocks.extend(get_inputs_blocks(inputs=self.inputs))
         self.inputs["ts"] = self.ts
         self.inputs["requesters_channel"] = self.requesters_channel

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -17,7 +17,6 @@ class SlackProvision:
         self.headers = request.headers
         self.payload = json.loads(request.form["payload"])
         if self.from_reject_response():
-            self.reject_with_reason()
             return
         self.user_payload = self.payload["user"]
         self.action = self.payload["actions"][0]
@@ -66,6 +65,7 @@ class SlackProvision:
                 logger.info(f"Response not allowed for user {self.user}")
                 return 200
             else:
+                self.reject_with_reason()
                 logger.info(f"Action not found called by {self.user}")
                 return 200
 

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -154,8 +154,8 @@ class SlackProvision:
         blocks.extend(get_header_block(name=self.name))
         inputs = self.inputs.copy()
         inputs.pop("ts", None)
-        inputs.pop("requesters_channel")
-        inputs.pop("approvers_channel")
+        inputs.pop("requesters_channel", None)
+        inputs.pop("approvers_channel", None)
         blocks.extend(get_inputs_blocks(inputs=self.inputs))
         self.inputs["ts"] = self.ts
         self.inputs["requesters_channel"] = self.requesters_channel

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -35,6 +35,7 @@ class SlackProvision:
             self.get_private_metadata()
             self.action_id = "Modified"
             self.get_modified_fields()
+            self.send_status_message(status="Pending (modified) ")
             return
 
         self.user_payload = self.payload["user"]

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -418,8 +418,8 @@ class SlackProvision:
 
         for block_name, block_values in blocks.items():
             new_value = block_values[f"action_id_{block_name}"]["value"]
-            if new_value == "" or new_value is None:
-                continue
+            if new_value is None:
+                new_value = ""
             self.inputs["modified"] = True
             self.inputs[re.sub(r"_\d+$", '', block_name)].append(new_value)
 

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -15,6 +15,7 @@ class SlackProvision:
         self.headers = request.headers
         payload = json.loads(request.form["payload"])
         self.payload = payload
+        logger.info(self.payload)
         action = payload["actions"][0]
         self.action_id = action["action_id"]
         self.inputs = json.loads(action["value"])
@@ -32,7 +33,6 @@ class SlackProvision:
         self.user_payload = payload["user"]
         self.requester = self.inputs["requester"] if "requester" in self.inputs else ""
 
-        logger.info(payload)
         # Requester can response depending on flag for prevent self approval and user-requester values
         if not self.can_response():
             self.action_id = "Not allowed"

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -121,9 +121,9 @@ class SlackProvision:
             response = slack_web_client.chat_update(
                 channel=self.approvers_channel,
                 ts=self.ts,
-                text="fallback",
                 #blocks=blocks,
                 as_user=True,
+                text="Hola"
             )
             logger.info(response.status_code)
         except errors.SlackApiError as e:
@@ -149,7 +149,6 @@ class SlackProvision:
             response = slack_web_client.chat_update(
                 channel=self.requesters_channel,
                 ts=self.ts,
-                text="fallback",
                 blocks=blocks,
             )
         except errors.SlackApiError as e:

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -76,7 +76,7 @@ class SlackProvision:
                 self.rejected()
                 self.send_thread_message(message=self.reason, thread=self.response_url)
                 self.send_thread_message(
-                    message=self.reason, thread=self.requesters_channel
+                    message=self.reason, thread=self.channel_id
                 )
                 self.send_status_message(
                     requester_status="Rejected", approver_status="Rejected"

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -275,7 +275,7 @@ class SlackProvision:
         metadata = json.loads(self.payload["view"]["private_metadata"])
         self.channel_id = metadata["channel_id"]
         self.requesters_ts = metadata["requesters_ts"]
-        self.approvers_ts = metadata["message_ts"]
+        self.approvers_ts = metadata["approvers_ts"]
         self.inputs = metadata["inputs"]
         self.name = self.inputs["provision_class"]
         self.user = metadata["user"]

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -142,6 +142,7 @@ class SlackProvision:
             "response_url": self.response_url,
             "requesters_channel": self.requesters_channel,
             "token": self.token,
+            "ts": self.ts
         }
         try:
             client = WebClient(self.token)
@@ -198,7 +199,7 @@ class SlackProvision:
     def get_private_metadata(self):
         metadata = json.loads(self.payload["view"]["private_metadata"])
         self.channel_id = metadata["channel_id"]
-        self.ts = metadata["message_ts"]
+        self.ts = metadata["ts"]
         self.inputs = metadata["inputs"]
         self.name = self.inputs["provision_class"]
         self.user = metadata["user"]

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -222,8 +222,8 @@ class SlackProvision:
         metadata = json.loads(self.payload['view']['private_metadata'])
         channel_id = metadata["channel_id"]
         ts = metadata["message_ts"]
-        self.name = metadata["provision_class"]
         self.inputs = metadata["inputs"]
+        self.name = self.inputs["provision_class"]
         self.user = metadata["user"]
         self.response_url = metadata["response_url"]
         self.requesters_channel = metadata["requesters_channel"]

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -335,7 +335,7 @@ class SlackProvision:
             if isinstance(modifiable_field_value, list):
                 item_number = 0
                 for value in modifiable_field_value:
-                    value = value if value != "" else "no value",
+                    value = value if value != "" else "no value"
                     field = {
                         "type": "input",
                         "block_id": f"multivalue_block_id_{modifiable_field_name}_{item_number}",

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -29,9 +29,6 @@ class SlackProvision:
         self.ts = self.inputs.pop("ts")
         self.requesters_channel = self.inputs.pop("requesters_channel")
         logger.info(f"Approve or Reject or Not Allowd action_id payload = {self.payload}")
-        return
-
-
         self.approvers_channel = self.inputs.pop("approvers_channel", None)
         self.user = " ".join(
             [s.capitalize() for s in self.payload["user"]["name"].split(".")]

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -336,7 +336,7 @@ class SlackProvision:
                     },
                     "element": {
                         "type": "plain_text_input",
-                        "action_id": "input_modifiable_field_name",
+                        "action_id": f"input_{modifiable_field_name}",
                         "placeholder": {
                             "type": "plain_text",
                             "text": modifiable_field_value
@@ -346,6 +346,7 @@ class SlackProvision:
                     "optional": True
                 }
             blocks.append(field)
+        logger.info(f"blocks={blocks}")
         return blocks
 
     def capture_modifiable_fields(self):

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -25,7 +25,6 @@ class SlackProvision:
         self.data = request.get_data()
         self.headers = request.headers
         self.payload = json.loads(request.form["payload"])
-        logger.info(f"original payload = {self.payload}")
         # Comes from the reject response modal view (data comes in private metadata)
         if self.is_callback_view(callback_id="reject_reason_modal"):
             # Some vars need to be defined so IDE dont complain
@@ -40,11 +39,9 @@ class SlackProvision:
         elif self.is_callback_view(callback_id="edit_view_modal"):
             self.channel_id = None
             self.reason = None
-            logger.info(self.payload)
             self.get_private_metadata()
             self.action_id = "Modified"
             self.get_modified_fields()
-            logger.info(f"payload {self.payload}")
             return
 
         self.user_payload = self.payload["user"]
@@ -110,11 +107,9 @@ class SlackProvision:
                 # Update status on messages
                 self.send_status_message(status="Rejected")
             elif self.action_id == "Edit":
-                logger.info(f"Initial inputs = {self.inputs}")
                 self.open_edit_view()
             elif self.action_id == "Modified":
                 self.send_modified_message()
-                logger.info(f"Modified inputs = {self.inputs}")
 
         except Exception as e:
             self.exception = e
@@ -130,7 +125,6 @@ class SlackProvision:
             # Message to approver
             slack_client = WebhookClient(self.response_url)
             response = slack_client.send(text="fallback", blocks=blocks)
-            logger.info(response.status_code)
         except errors.SlackApiError as e:
             self.exception = e
             logger.error(e)
@@ -386,7 +380,6 @@ class SlackProvision:
             }
             client = WebClient(self.token)
             client.views_open(trigger_id=self.payload["trigger_id"], view=modal_view)
-            logger.info(f"modal view =   {modal_view}")
         except errors.SlackApiError as e:
             self.exception = e
             logger.error(e)

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -15,17 +15,16 @@ class SlackProvision:
         self.token = os.environ.get("SLACK_BOT_TOKEN")
         self.data = request.get_data()
         self.headers = request.headers
-        payload = json.loads(request.form["payload"])
-        self.payload = payload
-        self.response_url = self.payload["response_url"]
-        self.user_payload = payload["user"]
+        self.payload = json.loads(request.form["payload"])
+        self.user_payload = self.payload["user"]
         logger.info(self.payload)
 
         if self.from_reject_response():
             self.reject_with_reason()
             return
 
-        action = payload["actions"][0]
+        action = self.payload["actions"][0]
+        self.response_url = self.payload["response_url"]
         self.action_id = action["action_id"]
         self.inputs = json.loads(action["value"])
         self.ts = self.inputs.pop("ts")

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -87,12 +87,24 @@ class SlackProvision:
                 #     channel=self.channel_id,
                 #     mention_requester=True
                 # )
-                self.send_message_to_thread(
-                    message=message,
+                # self.send_message_to_thread(
+                #     message=message,
+                #     thread_ts=self.requesters_ts,
+                #     channel=self.requesters_channel,
+                #     mention_requester=True
+                # )
+                import asyncio
+                asyncio.run(self.send_message_to_thread(message=message,
                     thread_ts=self.requesters_ts,
                     channel=self.requesters_channel,
-                    mention_requester=True
-                )
+                    mention_requester=True))
+
+                asyncio.run(self.send_message_to_thread(message=message,
+                                                        thread_ts=self.approvers_ts,
+                                                        channel=self.channel_id,
+                                                        mention_requester=True))
+
+
             elif self.action_id == "Edit":
                 self.open_edit_view()
                 return
@@ -165,12 +177,12 @@ class SlackProvision:
         self.send_message_approver(blocks)
         self.send_message_requester(blocks)
 
-    def send_message_to_thread(self, message, thread_ts, channel, mention_requester=False):
+    async def send_message_to_thread(self, message, thread_ts, channel, mention_requester=False):
         try:
             if mention_requester:
                 message = f"<@{self.user_id}> {message}"
             client = WebClient(self.token)
-            client.chat_postMessage(
+            response = await client.chat_postMessage(
                 channel=channel,
                 thread_ts=thread_ts,
                 text=message,

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -194,11 +194,12 @@ class SlackProvision:
         try:
             client = WebClient(self.token)
             response = client.views_open(
-                trigger_id="1",
+                trigger_id=self.payload["trigger_id"],
                 view={
                     "type": "modal",
                     "callback_id": "reject_reason_modal",
                     "private_metadata": json.dumps(private_metadata),
+                    "response_action": "clear",
                     "title": {
                         "type": "plain_text",
                         "text": "Deny Reason"

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -18,6 +18,7 @@ class SlackProvision:
         self.payload = json.loads(request.form["payload"])
         if self.from_reject_response():
             logger.info(f"Reject response. Payload = {self.payload}")
+            self.load_payload()
             self.reject_with_reason()
             # self.reject_with_reason()
             return
@@ -220,3 +221,6 @@ class SlackProvision:
 
     def from_reject_response(self):
         return self.payload["type"] == "view_submission" and "view" in self.payload and "callback_id" in self.payload["view"] and self.payload["view"]["callback_id"] == "reject_reason_modal"
+
+    def load_payload(self):
+        self.name = self.inputs["provision_class"]

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -12,6 +12,7 @@ logger.setLevel(logging.DEBUG)
 class SlackProvision:
     def __init__(self, request, requesters_channel=None):
         self.exception = None
+        self.message_ts = None
         self.token = os.environ.get("SLACK_BOT_TOKEN")
         self.data = request.get_data()
         self.headers = request.headers
@@ -181,6 +182,11 @@ class SlackProvision:
                 thread_ts=self.ts,
                 text=f"Reason for rejection: {self.reason}",
             )
+            client.chat_postMessage(
+                channel=self.requesters_channel,
+                thread_ts=self.message_ts,
+                text=f"Reason for rejection: {self.reason}",
+            )
         except errors.SlackApiError as e:
             logger.error(e)
 
@@ -200,6 +206,7 @@ class SlackProvision:
         metadata = json.loads(self.payload["view"]["private_metadata"])
         self.channel_id = metadata["channel_id"]
         self.ts = metadata["ts"]
+        self.message_ts = metadata["message_ts"]
         self.inputs = metadata["inputs"]
         self.name = self.inputs["provision_class"]
         self.user = metadata["user"]

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -169,7 +169,7 @@ class SlackProvision:
             blocks
         )
 
-        blocks = []z
+        blocks = []
         blocks.extend(get_header_block(name=self.name))
         blocks.extend(get_inputs_blocks(self.inputs))
         self.inputs["requesters_ts"] = self.requesters_ts

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -139,8 +139,10 @@ class SlackProvision:
                 blocks=blocks,
             )
             logger.info(response.status_code)
+            return response.status_code
         except errors.SlackApiError as e:
             logger.error(e)
+        return 200
 
     def can_response(self):
         if not self.prevent_self_approval:
@@ -243,7 +245,7 @@ class SlackProvision:
             logger.error(e)
 
         self.send_status_message()
-        self.rejected()
+
 
     def from_reject_response(self):
         return self.payload["type"] == "view_submission" and "view" in self.payload and "callback_id" in self.payload["view"] and self.payload["view"]["callback_id"] == "reject_reason_modal"

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -175,6 +175,8 @@ class SlackProvision:
         self.inputs["requesters_ts"] = self.requesters_ts
         self.inputs["requesters_channel"] = self.requesters_channel
         self.inputs["approvers_channel"] = self.approvers_channel
+        self.inputs["modifiables_fields"] = ";".join(list(self.modifiables_fields.keys()))
+
         values = self.inputs.copy()
         blocks.extend(get_buttons_blocks(value=json.dumps(values)))
         self.send_message_approver(blocks)
@@ -325,6 +327,7 @@ class SlackProvision:
 
     def open_edit_view(self):
         logger.info(self.payload)
+        self.inputs["modifiables_fields"] = ";".join(list(self.modifiables_fields.keys()))
         private_metadata = {
             "channel_id": self.payload["channel"]["id"],
             "approvers_ts": self.payload["message"]["ts"],
@@ -383,7 +386,6 @@ class SlackProvision:
         return blocks
 
     def get_modifiable_fields(self):
-        logger.info(getattr(self, "modifiables_fields", "None"))
         modifiables_fields_names = self.inputs.pop("modifiables_fields","")
         fields = modifiables_fields_names.split(";")
         modifiables_fields = {}

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -346,7 +346,7 @@ class SlackProvision:
                                 "type": "plain_text",
                                 "text": value,
                             },
-                            "initial_value": value,
+                            "initial_value": value if value != "" else "no value",
                             "multiline": False,
                         },
                         "optional": True,

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -345,7 +345,7 @@ class SlackProvision:
                             "action_id": f"action_id_{modifiable_field_name}_{item_number}",
                             "placeholder": {
                                 "type": "plain_text",
-                                "text": value,
+                                "text": "value",
                             },
                             "initial_value": value,
                             "multiline": False,

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -57,7 +57,38 @@ class SlackProvision:
             if self.action_id == "Approved":
                 self.approved()
             elif self.action_id == "Rejected":
-                self.rejected()
+                client = WebClient(self.token)
+                client.views_open(
+                    trigger_id=self.payload['trigger_id'],
+                    view={
+                        "type": "modal",
+                        "callback_id": "reason_modal",
+                        "title": {
+                            "type": "plain_text",
+                            "text": "Denial Reason"
+                        },
+                        "blocks": [
+                            {
+                                "type": "input",
+                                "block_id": "reason_block",
+                                "label": {
+                                    "type": "plain_text",
+                                    "text": "Please provide a reason for denial:"
+                                },
+                                "element": {
+                                    "type": "plain_text_input",
+                                    "action_id": "reason_input"
+                                }
+                            }
+                        ],
+                        "submit": {
+                            "type": "plain_text",
+                            "text": "Submit"
+                        }
+                    }
+                )
+                return
+                # self.rejected()
             elif self.action_id == "Not allowed":
                 self.send_not_allowed_message()
                 logger.info(f"Response not allowed for user {self.user}")

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -153,7 +153,7 @@ class SlackProvision:
         blocks = []
         blocks.extend(get_header_block(name=self.name))
         inputs = self.inputs.copy()
-        inputs.pop("ts")
+        inputs.pop("ts", None)
         inputs.pop("requesters_channel")
         inputs.pop("approvers_channel")
         blocks.extend(get_inputs_blocks(inputs=self.inputs))

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -286,6 +286,7 @@ class SlackProvision:
         self.token = metadata["token"]
         self.exception = None
         self.requester = metadata["requester"]
+        self.prevent_self_approval = metadata["prevent_self_approval"]
 
 
     def get_status_blocks(self, status):

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -18,7 +18,6 @@ class SlackProvision:
         self.payload = json.loads(request.form["payload"])
         if self.from_reject_response():
             logger.info(f"Reject response. Payload = {self.payload}")
-            self.load_payload()
             self.reject_with_reason()
             # self.reject_with_reason()
             return

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -17,10 +17,10 @@ class SlackProvision:
         self.headers = request.headers
         self.payload = json.loads(request.form["payload"])
         if self.from_reject_response():
-            logger.info(f"Reject response. Payload = {self.payload}")
+            return 200
+            # logger.info(f"Reject response. Payload = {self.payload}")
             self.reject_with_reason()
-            # self.reject_with_reason()
-            return
+            # return
         self.user_payload = self.payload["user"]
         self.action = self.payload["actions"][0]
         self.inputs = json.loads(self.action["value"])

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -54,6 +54,7 @@ class SlackProvision:
 
         self.name = self.inputs["provision_class"]
         self.ts = self.inputs.pop("ts")
+        self.ts_2 = self.payload["container"]["message_ts"]
         self.requesters_channel = self.inputs.pop("requesters_channel")
         self.approvers_channel = self.inputs.pop("approvers_channel", None)
         self.requester = self.inputs.get("requester", "")
@@ -121,7 +122,7 @@ class SlackProvision:
             slack_web_client = WebClient(self.token)
             response = slack_web_client.chat_update(
                 channel=self.approvers_channel,
-                ts=self.ts,
+                ts=self.ts_2,
                 blocks=blocks,
                 as_user=True,
                 text=""

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -37,7 +37,6 @@ class SlackProvision:
         elif self.is_callback_view(callback_id="edit_view_modal"):
             self.channel_id = None
             self.reason = None
-            logger.info(self.payload)
             self.get_private_metadata()
             self.action_id = "Modified"
             self.get_modified_fields()
@@ -204,6 +203,7 @@ class SlackProvision:
             logger.error(e)
 
     def open_reject_reason_view(self):
+        logger.info(self.payload)
         private_metadata = {
             "channel_id": self.payload["channel"]["id"],
             "approvers_ts": self.payload["message"]["ts"],

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -50,10 +50,10 @@ class SlackProvision:
         self.user = self.parse_user()
 
         self.name = self.inputs["provision_class"]
-        self.requesters_ts = self.inputs.pop("requesters_ts", self.requesters_ts)
+        self.requesters_ts = self.inputs.pop("requesters_ts")
         self.approvers_ts = self.payload["container"]["message_ts"]
-        self.requesters_channel = self.inputs.pop("requesters_channel", self.requesters_channel)
-        self.approvers_channel = self.inputs.pop("approvers_channel", self.approvers_channel)
+        self.requesters_channel = self.inputs.pop("requesters_channel")
+        self.approvers_channel = self.inputs.pop("approvers_channel")
         self.requester = self.inputs.get("requester", "")
         self.modifiables_fields = self.get_modifiable_fields()
         """ Requester can response depending on flag for prevent self approval and user-requester values
@@ -161,10 +161,6 @@ class SlackProvision:
         inputs.pop("ts", None)
         inputs.pop("requesters_channel", None)
         inputs.pop("approvers_channel", None)
-        # self.inputs["requesters_ts"] = self.requesters_ts
-        # self.inputs["requesters_channel"] = self.requesters_channel
-        # self.inputs["approvers_channel"] = self.approvers_channel
-        values = self.inputs
         blocks = []
         blocks.extend(get_header_block(name=self.name))
         blocks.extend(get_inputs_blocks(self.inputs))
@@ -173,6 +169,10 @@ class SlackProvision:
             blocks
         )
 
+        self.inputs["requesters_ts"] = self.requesters_ts
+        self.inputs["requesters_channel"] = self.requesters_channel
+        self.inputs["approvers_channel"] = self.approvers_channel
+        values = self.inputs
         blocks = []
         blocks.extend(get_header_block(name=self.name))
         blocks.extend(get_inputs_blocks(self.inputs))

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -205,7 +205,7 @@ class SlackProvision:
                             "block_id": "reason_block",
                             "label": {
                                 "type": "plain_text",
-                                "text": "Please provide a reason for deny:"
+                                "text": "Please provide a reason for rejection:"
                             },
                             "element": {
                                 "type": "plain_text_input",
@@ -242,7 +242,7 @@ class SlackProvision:
             client.chat_postMessage(
                 channel=channel_id,
                 thread_ts=self.ts,
-                text=f"Reason for denial: {reason}"
+                text=f"Reason for rejection: {reason}"
             )
         except errors.SlackApiError as e:
             logger.error(e)

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -158,7 +158,6 @@ class SlackProvision:
                 self.inputs.pop(field, None)
             self.inputs.pop("hide")
         inputs = self.inputs.copy()
-        inputs.pop("ts", None)
         inputs.pop("requesters_channel", None)
         inputs.pop("approvers_channel", None)
         inputs.pop("modifiables_fields", None)
@@ -221,6 +220,7 @@ class SlackProvision:
             "approvers_channel": self.approvers_channel,
             "requester": self.requester,
             "prevent_self_approval": self.prevent_self_approval,
+            "modifiables_fields": self.modifiables_fields
         }
         try:
             client = WebClient(self.token)

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -77,7 +77,7 @@ class SlackProvision:
                 return
             elif self.action_id == "Reject Response":
                 self.rejected()
-                message = f"Reason for rejection: {self.reason}"
+                message = f"<@{self.user_id}> Reason for rejection: {self.reason}"
                 # Message to approver same request message thread
                 self.send_message_to_thread(
                     message=message,

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -115,18 +115,30 @@ class SlackProvision:
         self.send_status_message(status=self.action_id)
 
     def send_message_approver(self, blocks):
-        hide = self.inputs.get("hide")
-        if hide:
-            for field in hide:
-                self.inputs.pop(field, None)
-            self.inputs.pop("hide")
         try:
-            # Message to approver
-            slack_client = WebhookClient(self.response_url)
-            response = slack_client.send(text="fallback", blocks=blocks)
+            # Message to requester
+            slack_web_client = WebClient(self.token)
+            response = slack_web_client.chat_update(
+                channel=self.approvers_channel,
+                ts=self.ts,
+                text="fallback",
+                blocks=blocks,
+            )
         except errors.SlackApiError as e:
             self.exception = e
             logger.error(e)
+        # hide = self.inputs.get("hide")
+        # if hide:
+        #     for field in hide:
+        #         self.inputs.pop(field, None)
+        #     self.inputs.pop("hide")
+        # try:
+        #     # Message to approver
+        #     slack_client = WebhookClient(self.response_url)
+        #     response = slack_client.send(text="fallback", blocks=blocks)
+        # except errors.SlackApiError as e:
+        #     self.exception = e
+        #     logger.error(e)
 
     def send_message_requester(self, blocks):
         try:
@@ -166,7 +178,7 @@ class SlackProvision:
             )
         )
         blocks.extend(get_buttons_blocks(value=json.dumps(values)))
-        #self.send_message_approver(blocks)
+        self.send_message_approver(blocks)
 
     def send_status_message(self, status):
         hide = self.inputs.get("hide")

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -175,44 +175,47 @@ class SlackProvision:
         private_metadata = {
             "channel_id": self.payload['channel']['id'],
             "message_ts": self.payload['message']['ts'],
-            "name": self.payload["provision_class"],
+            "name": self.inputs["provision_class"],
             "inputs": self.inputs,
             "user": self.user,
             "response_url": self.response_url,
             "requesters_channel": self.requesters_channel,
             "token": self.token
             }
-        client = WebClient(self.token)
-        client.views_open(
-            trigger_id=self.payload['trigger_id'],
-            view={
-                "type": "modal",
-                "callback_id": "reject_reason_modal",
-                "private_metadata": json.dumps(private_metadata),
-                "title": {
-                    "type": "plain_text",
-                    "text": "Deny Reason"
-                },
-                "blocks": [
-                    {
-                        "type": "input",
-                        "block_id": "reason_block",
-                        "label": {
-                            "type": "plain_text",
-                            "text": "Please provide a reason for deny:"
-                        },
-                        "element": {
-                            "type": "plain_text_input",
-                            "action_id": "reject_reason_input"
+        try:
+            client = WebClient(self.token)
+            client.views_open(
+                trigger_id=self.payload['trigger_id'],
+                view={
+                    "type": "modal",
+                    "callback_id": "reject_reason_modal",
+                    "private_metadata": json.dumps(private_metadata),
+                    "title": {
+                        "type": "plain_text",
+                        "text": "Deny Reason"
+                    },
+                    "blocks": [
+                        {
+                            "type": "input",
+                            "block_id": "reason_block",
+                            "label": {
+                                "type": "plain_text",
+                                "text": "Please provide a reason for deny:"
+                            },
+                            "element": {
+                                "type": "plain_text_input",
+                                "action_id": "reject_reason_input"
+                            }
                         }
+                    ],
+                    "submit": {
+                        "type": "plain_text",
+                        "text": "Submit"
                     }
-                ],
-                "submit": {
-                    "type": "plain_text",
-                    "text": "Submit"
                 }
-            }
-        )
+            )
+        except errors.SlackApiError as e:
+            logger.error(e)
 
     def reject_with_reason(self):
         logger.info("reject_with_reason")

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -67,7 +67,7 @@ class SlackProvision:
             elif self.action_id == "Not allowed":
                 message = f"Same request/response user {self.user} not allowed. Prevent self approval is on."
                 self.send_message_to_thread(message=message, thread_ts=self.ts, channel=self.channel_id)
-                self.send_message_to_thread(message=message, thread_ts=self.message_ts, channel=self.requesters_channel)
+                self.send_message_to_thread(message=message, thread_ts=self.ts, channel=self.requesters_channel)
             elif self.action_id == "Reject Response":
                 self.rejected()
                 message = f"Reason for rejection: {self.reason}"

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -45,7 +45,7 @@ class SlackProvision:
             self.get_private_metadata()
             self.action_id = "Modified"
             self.get_modified_fields()
-            # self.send_modified_message()
+            self.send_modified_message()
             return
 
         self.user_payload = self.payload["user"]

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -197,7 +197,7 @@ class SlackProvision:
                     "private_metadata": json.dumps(private_metadata),
                     "title": {
                         "type": "plain_text",
-                        "text": "Deny Reason"
+                        "text": "Reject Reason"
                     },
                     "blocks": [
                         {

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -122,7 +122,7 @@ class SlackProvision:
                 self.inputs.pop("hide")
 
             # Message to requester
-            slack_web_client = await AsyncWebClient(self.token)
+            slack_web_client = WebClient(self.token)
             response = slack_web_client.chat_update(
                 channel=self.approvers_channel,
                 ts=self.approvers_ts,
@@ -137,7 +137,7 @@ class SlackProvision:
     def send_message_requester(self, blocks):
         try:
             # Message to requester
-            slack_web_client = await AsyncWebClient(self.token)
+            slack_web_client = WebClient(self.token)
             response = slack_web_client.chat_update(
                 channel=self.requesters_channel,
                 ts=self.requesters_ts,

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -39,12 +39,13 @@ class SlackProvision:
         elif self.is_callback_view(callback_id="edit_view_modal"):
             self.channel_id = None
             self.reason = None
-            self.action = self.payload["actions"][0]
-            self.inputs = json.loads(self.action["value"])
-            self.get_private_metadata()
-            self.action_id = "Modified"
-            self.get_modified_fields()
-            self.send_modified_message()
+            logger.info(self.payload)
+            # self.action = self.payload["actions"][0]
+            # self.inputs = json.loads(self.action["value"])
+            # self.get_private_metadata()
+            # self.action_id = "Modified"
+            # self.get_modified_fields()
+            # self.send_modified_message()
             return
 
         self.user_payload = self.payload["user"]

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -207,7 +207,6 @@ class SlackProvision:
             slack_web_client = WebClient(self.token)
             user_info = slack_web_client.users_info(user=self.user_payload["id"])
             user_email = user_info["user"]["profile"]["email"]
-            logger.info(f"{user_email} <> {self.requester} <> {self.action_id}")
             if user_email == self.requester and self.action_id == "Approved":
                 return False
             else:

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -198,7 +198,6 @@ class SlackProvision:
             slack_web_client = WebClient(self.token)
             user_info = slack_web_client.users_info(user=self.user_payload["id"])
             user_email = user_info["user"]["profile"]["email"]
-            logger.info(f"user_email={user_email}, requester={self.requester}")
             if user_email == self.requester and self.action_id == "Approved":
                 return False
             else:

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -20,7 +20,7 @@ class SlackProvision:
         self.data = request.get_data()
         self.headers = request.headers
         self.payload = json.loads(request.form["payload"])
-
+        logger.info(f"original payload = {self.payload}")
         # Comes from the reject response modal view (data comes in private metadata)
         if self.is_callback_view(callback_id="reject_reason_modal"):
             # Some vars need to be defined so IDE dont complain
@@ -36,13 +36,10 @@ class SlackProvision:
             self.channel_id = None
             self.reason = None
             logger.info(self.payload)
-            # self.action = self.payload["actions"][0]
-            # self.inputs = json.loads(self.action["value"])
             self.get_private_metadata()
             self.action_id = ""
             self.get_modified_fields()
             logger.info(f"payload {self.payload}")
-            logger.info(f"data = {self.data}")
             # self.send_modified_message()
             return
 

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -339,7 +339,7 @@ class SlackProvision:
                 #     "optional": True,
                 # }
                 field = {
-                    "type": "input",
+                    "type": "actions",
                     "block_id": f"block_id_{modifiable_field_name}",
                     "label": {"type": "plain_text", "text": modifiable_field_name},
                     "elements": elements,
@@ -359,23 +359,23 @@ class SlackProvision:
                 blocks.append(field)
                 blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": "Modifiable fields"}})
                 continue
-            field = {
-                "type": "input",
-                "block_id": f"block_id_{modifiable_field_name}",
-                "label": {"type": "plain_text", "text": modifiable_field_name},
-                "element": {
-                    "type": "plain_text_input",
-                    "action_id": f"action_id_{modifiable_field_name}",
-                    "placeholder": {
-                        "type": "plain_text",
-                        "text": modifiable_field_value,
-                    },
-                    "initial_value": modifiable_field_value,
-                    "multiline": False,
-                },
-                "optional": True,
-            }
-            blocks.append(field)
+            # field = {
+            #     "type": "input",
+            #     "block_id": f"block_id_{modifiable_field_name}",
+            #     "label": {"type": "plain_text", "text": modifiable_field_name},
+            #     "element": {
+            #         "type": "plain_text_input",
+            #         "action_id": f"action_id_{modifiable_field_name}",
+            #         "placeholder": {
+            #             "type": "plain_text",
+            #             "text": modifiable_field_value,
+            #         },
+            #         "initial_value": modifiable_field_value,
+            #         "multiline": False,
+            #     },
+            #     "optional": True,
+            # }
+            # blocks.append(field)
         return blocks
 
     def get_modifiable_fields(self):

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -66,7 +66,7 @@ class SlackProvision:
                 self.open_reject_reason_view()
             elif self.action_id == "Not allowed":
                 message = f"Same request/response user {self.user} not allowed. Prevent self approval is on."
-                self.open_dialog(message=message)
+                self.open_dialog(title="Warning", message=message)
                 self.send_message_to_thread(message=message, thread_ts=self.ts, channel=self.requesters_channel)
             elif self.action_id == "Reject Response":
                 self.rejected()
@@ -279,7 +279,7 @@ class SlackProvision:
             )
         return blocks
 
-    def open_dialog(self, message):
+    def open_dialog(self, title, message):
         try:
             client = WebClient(self.token)
             client.views_open(

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -320,7 +320,7 @@ class SlackProvision:
 
     def construct_modifiable_fields_blocks(self):
         blocks = []
-        for modifiable_field_name, modifiable_field_value in self.modifiables_fields:
+        for modifiable_field_name, modifiable_field_value in self.modifiables_fields.items():
             field_block = [
                 {
                     "type": "section",

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -348,8 +348,8 @@ class SlackProvision:
                     }
                     blocks.append(field)
                     continue
-                for value in modifiable_field_value:
-                    value = value if value != "" else "no value"
+                for valid_value in modifiable_field_value:
+                    valid_value = valid_value if valid_value != "" and valid_value is not None else "no value"
                     field = {
                         "type": "input",
                         "block_id": f"multivalue_block_id_{modifiable_field_name}_{item_number}",
@@ -361,7 +361,7 @@ class SlackProvision:
                                 "type": "plain_text",
                                 "text": "Insert value (empty to remove)",
                             },
-                            "initial_value": value,
+                            "initial_value": valid_value,
                             "multiline": False,
                         },
                         "optional": True,
@@ -369,7 +369,7 @@ class SlackProvision:
                     blocks.append(field)
                     item_number += 1
                 continue
-            value = modifiable_field_value if modifiable_field_value != "" else "no value"
+            valid_value = modifiable_field_value if modifiable_field_value != "" and modifiable_field_value is not None else "no value"
 
             field = {
                 "type": "input",
@@ -382,7 +382,7 @@ class SlackProvision:
                         "type": "plain_text",
                         "text": "Insert value (empty to remove)",
                     },
-                    "initial_value": value,
+                    "initial_value": valid_value,
                     "multiline": False,
                 },
                 "optional": True,

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -285,6 +285,7 @@ class SlackProvision:
         self.requesters_channel = metadata["requesters_channel"]
         self.token = metadata["token"]
         self.exception = None
+        self.requester = metadata["requester"]
 
     def get_status_blocks(self, status):
         blocks = []

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -5,8 +5,14 @@ import logging
 from slack_sdk.signature import SignatureVerifier
 from slack_sdk import WebhookClient, WebClient, errors
 
+from slack_approval.utils import get_header_block, get_inputs_blocks, get_status_block, get_exception_block
+
 logger = logging.getLogger("slack_provision")
 logger.setLevel(logging.DEBUG)
+
+
+
+
 
 
 class SlackProvision:
@@ -231,50 +237,53 @@ class SlackProvision:
         self.exception = None
 
     def get_base_blocks(self, status):
-        blocks = [
-            {
-                "type": "header",
-                "text": {
-                    "type": "plain_text",
-                    "text": self.name,
-                    "emoji": True,
-                },
-            },
-            {"type": "divider"},
-        ]
-        input_blocks = [
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": f"*{' '.join([s.capitalize() for s in key.split('_')])}:* {value}",
-                },
-            }
-            for key, value in self.inputs.items()
-            if key != "provision_class"
-        ]
-        blocks.extend(input_blocks)
-        blocks.append({"type": "divider"})
-        blocks.append(
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": f"*Status: {status} by {self.user}*",
-                },
-            }
-        )
+        blocks = []
+
+        # blocks = [
+        #     {
+        #         "type": "header",
+        #         "text": {
+        #             "type": "plain_text",
+        #             "text": self.name,
+        #             "emoji": True,
+        #         },
+        #     },
+        #     {"type": "divider"},
+        # ]
+
+        blocks.extend(get_header_block(name=self.name))
+
+        # input_blocks = [
+        #     {
+        #         "type": "section",
+        #         "text": {
+        #             "type": "mrkdwn",
+        #             "text": f"*{' '.join([s.capitalize() for s in key.split('_')])}:* {value}",
+        #         },
+        #     }
+        #     for key, value in self.inputs.items()
+        #     if key != "provision_class"
+        # ]
+        # blocks.extend(input_blocks)
+        # blocks.append({"type": "divider"})
+
+        blocks.extend(get_inputs_blocks(self.inputs))
+
+        # blocks.append(
+        #     {
+        #         "type": "section",
+        #         "text": {
+        #             "type": "mrkdwn",
+        #             "text": f"*Status: {status} by {self.user}*",
+        #         },
+        #     }
+        # )
+
+        blocks.extend(get_status_block(status=status, user=self.user))
+
         if self.exception:
-            blocks.append({"type": "divider"})
-            blocks.append(
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": f"Error while provisioning: {self.exception}",
-                    },
-                }
-            )
+            blocks.extend(get_exception_block(self.exception))
+
         return blocks
 
     def open_dialog(self, title, message):

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -176,22 +176,6 @@ class SlackProvision:
         except errors.SlackApiError as e:
             logger.error(e)
 
-    def send_reject_reason(self):
-        try:
-            client = WebClient(self.token)
-            client.chat_postMessage(
-                channel=self.channel_id,
-                thread_ts=self.ts,
-                text=f"Reason for rejection: {self.reason}",
-            )
-            client.chat_postMessage(
-                channel=self.requesters_channel,
-                thread_ts=self.message_ts,
-                text=f"Reason for rejection: {self.reason}",
-            )
-        except errors.SlackApiError as e:
-            logger.error(e)
-
     def send_message_to_thread(self, message, thread_ts, channel):
         try:
             client = WebClient(self.token)
@@ -286,7 +270,7 @@ class SlackProvision:
                 trigger_id=self.payload["trigger_id"],
                 view={
                     "type": "modal",
-                    "title": {"type": "plain_text", "text": "Info"},
+                    "title": {"type": "plain_text", "text": title},
                     "close": {"type": "plain_text", "text": "Close"},
                     "blocks": [
                         {

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -383,7 +383,7 @@ class SlackProvision:
         return blocks
 
     def get_modifiable_fields(self):
-        if self.modifiables_fields is not None:
+        if getattr(self, "modifiables_fields", None) is not None:
             return self.modifiables_fields
         modifiables_fields_names = self.inputs.pop("modifiables_fields","")
         fields = modifiables_fields_names.split(";")

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -199,7 +199,6 @@ class SlackProvision:
                     "type": "modal",
                     "callback_id": "reject_reason_modal",
                     "private_metadata": json.dumps(private_metadata),
-                    "response_action": "clear",
                     "title": {
                         "type": "plain_text",
                         "text": "Deny Reason"

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -25,7 +25,6 @@ class SlackProvision:
         self.data = request.get_data()
         self.headers = request.headers
         self.payload = json.loads(request.form["payload"])
-        logger.info(self.payload)
         # Comes from the reject response modal view (data comes in private metadata)
         if self.is_callback_view(callback_id="reject_reason_modal"):
             # Some vars need to be defined so IDE dont complain
@@ -279,6 +278,7 @@ class SlackProvision:
         self.channel_id = metadata["channel_id"]
         self.ts = metadata["ts"]
         self.message_ts = metadata["message_ts"]
+        self.approvers_ts = metadata["message_ts"]
         self.inputs = metadata["inputs"]
         self.name = self.inputs["provision_class"]
         self.user = metadata["user"]

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -77,6 +77,7 @@ class SlackProvision:
 
         except Exception as e:
             self.exception = e
+            logger.error(e)
 
         hide = self.inputs.get("hide")
         if hide:

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -71,8 +71,8 @@ class SlackProvision:
                 self.send_not_allowed_message()
                 logger.info(f"Response not allowed for user {self.user}")
                 return
-            elif self.action_id == "Rejected with reason":
-                logger.info(f"Rejected with reason by {self.user}")
+            else:
+                logger.info(f"Action not found called by {self.user}")
                 return
 
         except Exception as e:
@@ -207,6 +207,8 @@ class SlackProvision:
         )
 
     def reject_with_reason(self):
+        logger.info("reject_with_reason")
+        return
         try:
             metadata = json.loads(self.payload['view']['private_metadata'])
             channel_id = metadata["channel_id"]

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -208,7 +208,7 @@ class SlackProvision:
             channel_id = metadata["channel_id"]
             ts = metadata["message_ts"]
             reason = self.payload['view']['state']['values']['reason_block']['reject_reason_input']['value']
-            client = WebClient(self.payload["token"])
+            client = WebClient(self.token)
             client.chat_postMessage(
                 channel=channel_id,
                 thread_ts=ts,

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -66,7 +66,7 @@ class SlackProvision:
                 self.is_open_reason_view()
             elif self.action_id == "Not allowed":
                 message = f"Same request/response user {self.user} not allowed. Prevent self approval is on."
-                self.send_message_to_thread(message=message, thread_ts=self.ts, channel=self.channel_id)
+                self.send_message_to_thread(message=message, thread_ts=self.ts, channel=self.approvers_channel)
                 self.send_message_to_thread(message=message, thread_ts=self.ts, channel=self.requesters_channel)
             elif self.action_id == "Reject Response":
                 self.rejected()

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -45,7 +45,7 @@ class SlackProvision:
             self.get_private_metadata()
             self.action_id = "Modified"
             self.get_modified_fields()
-            self.send_modified_message()
+            #self.send_modified_message()
             return
 
         self.user_payload = self.payload["user"]
@@ -111,7 +111,7 @@ class SlackProvision:
                 self.open_edit_view()
             elif self.action_id == "Modified":
                 self.open_dialog("Modification", "Success")
-                #self.send_modified_message()
+                self.send_modified_message()
                 logger.info(f"Modified inputs = {self.inputs}")
 
         except Exception as e:
@@ -156,9 +156,14 @@ class SlackProvision:
         blocks = []
         blocks.extend(get_header_block(name=self.name))
         blocks.extend(get_inputs_blocks(inputs=self.inputs))
-        blocks.extend(get_buttons_blocks(value=json.dumps(self.inputs.copy())))
+        values = {"provision_class": self.name, "ts": self.ts, "requesters_channel": self.requesters_channel,
+                  "approvers_channel": self.approvers_channel, "user": self.user, "requester": self.requester,
+                  "modifiables_fields": self.modifiables_fields, "prevent_self_approval": self.prevent_self_approval}
+
+        self.send_message_requester(blocks)
+        blocks.extend(get_buttons_blocks(value=json.dumps(values)))
         self.send_message_approver(blocks)
-        # self.send_message_requester(blocks)
+        
     def send_status_message(self, status):
         hide = self.inputs.get("hide")
         if hide:

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -221,4 +221,4 @@ class SlackProvision:
         self.rejected()
 
     def from_reject_response(self):
-        return self.payload["type"] == "view_submission" and "view" in self.payload and "callback_id" in self.payload["view_submisson"] and self.payload["view_submission"]["callback_id"] == "reject_reason_modal"
+        return self.payload["type"] == "view_submission" and "view" in self.payload and "callback_id" in self.payload["view"] and self.payload["view"]["callback_id"] == "reject_reason_modal"

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -107,7 +107,7 @@ class SlackProvision:
                 logger.info(f"Initial inputs = {self.inputs}")
                 self.open_edit_view()
             elif self.action_id == "Modified":
-                self.open_dialog("Modification", "Success")
+                #self.open_dialog("Modification", "Success")
                 self.send_modified_message()
                 logger.info(f"Modified inputs = {self.inputs}")
 
@@ -264,6 +264,7 @@ class SlackProvision:
         self.user = metadata["user"]
         self.response_url = metadata["response_url"]
         self.requesters_channel = metadata["requesters_channel"]
+        self.approvers_channel = metadata["approvers_channel"]
         self.token = metadata["token"]
         self.exception = None
         self.requester = metadata["requester"]

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -405,7 +405,7 @@ class SlackProvision:
 
         for block_name, block_values in blocks.items():
             new_value = block_values[f"action_id_{block_name}"]["value"]
-            if new_value == "":
+            if new_value == "" or new_value is None:
                 continue
             self.inputs["modified"] = True
             self.inputs[re.sub(r"_\d+$", '', block_name)].append(new_value)

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -319,17 +319,16 @@ class SlackProvision:
             logger.error(e)
 
     def construct_modifiable_fields_blocks(self):
-        blocks = []
-        for modifiable_field_name, modifiable_field_value in self.modifiables_fields.items():
-            field_block = [
-                {
+        blocks = [{
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
                         "text": "Modifiable fields"
                     }
-                },
-                {
+                }
+        ]
+        for modifiable_field_name, modifiable_field_value in self.modifiables_fields.items():
+            field = {
                     "type": "input",
                     "label": {
                         "type": "plain_text",
@@ -345,8 +344,8 @@ class SlackProvision:
                         "multiline": False
                     },
                     "optional": True
-                }]
-            blocks.append(field_block)
+                }
+            blocks.append(field)
         return blocks
 
     def capture_modifiable_fields(self):

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -17,20 +17,20 @@ class SlackProvision:
         self.headers = request.headers
         self.payload = json.loads(request.form["payload"])
         self.user_payload = self.payload["user"]
+        self.action = self.payload["actions"][0]
+        self.inputs = json.loads(self.action["value"])
+        self.name = self.inputs["provision_class"]
+        self.response_url = self.payload["response_url"]
+        self.action_id = self.action["action_id"]
+        self.ts = self.inputs.pop("ts")
+        self.requesters_channel = self.inputs.pop("requesters_channel")
         logger.info(self.payload)
         return
         if self.from_reject_response():
             self.reject_with_reason()
             return
 
-        action = self.payload["actions"][0]
-        self.response_url = self.payload["response_url"]
-        self.action_id = action["action_id"]
-        self.inputs = json.loads(action["value"])
-        self.ts = self.inputs.pop("ts")
-        self.requesters_channel = self.inputs.pop("requesters_channel")
         self.approvers_channel = self.inputs.pop("approvers_channel", None)
-        self.name = self.inputs["provision_class"]
         self.user = " ".join(
             [s.capitalize() for s in self.payload["user"]["name"].split(".")]
         )
@@ -219,4 +219,4 @@ class SlackProvision:
         self.rejected()
 
     def from_reject_response(self):
-        return "view" in self.payload and "callback_id" in self.payload and self.payload["callback_id"] == "reject_reason_modal"
+        return self.payload["type"] == "view_submission" and "view" in self.payload and "callback_id" in self.payload["view_submisson"] and self.payload["view_submission"]["callback_id"] == "reject_reason_modal"

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -88,6 +88,7 @@ class SlackProvision:
                 self.approved()
             elif self.action_id == "Rejected":
                 self.open_reject_reason_view()
+                return
             elif self.action_id == "Not allowed":
                 message = f"Same request/response user {self.user} not allowed. Prevent self approval is on."
                 self.open_dialog(title="Warning", message=message)

--- a/slack_approval/slack_provision.py
+++ b/slack_approval/slack_provision.py
@@ -82,15 +82,8 @@ class SlackProvision:
             elif self.action_id == "Reject Response":
                 self.rejected()
                 message = f"reason for rejection: {self.reason}"
-                asyncio.run(self.send_message_to_thread(message=message,
-                                                        thread_ts=self.requesters_ts,
-                                                        channel=self.requesters_channel,
-                                                        mention_requester=True))
-
-                asyncio.run(self.send_message_to_thread(message=message,
-                                                        thread_ts=self.approvers_ts,
-                                                        channel=self.channel_id,
-                                                        mention_requester=True))
+                asyncio.run(self.send_notifications(message=message, mention_requester=True))
+                
 
 
             elif self.action_id == "Edit":
@@ -129,8 +122,8 @@ class SlackProvision:
                 self.inputs.pop("hide")
 
             # Message to requester
-            slack_web_client = await AsyncWebClient(self.token)
-            response = slack_web_client.chat_update(
+            slack_web_client = AsyncWebClient(self.token)
+            response = await slack_web_client.chat_update(
                 channel=self.approvers_channel,
                 ts=self.approvers_ts,
                 blocks=blocks,
@@ -144,8 +137,8 @@ class SlackProvision:
     async def send_message_requester(self, blocks):
         try:
             # Message to requester
-            slack_web_client = await AsyncWebClient(self.token)
-            slack_web_client.chat_update(
+            slack_web_client = AsyncWebClient(self.token)
+            response = await slack_web_client.chat_update(
                 channel=self.requesters_channel,
                 ts=self.requesters_ts,
                 blocks=blocks,
@@ -486,3 +479,14 @@ class SlackProvision:
             "prevent_self_approval": self.prevent_self_approval,
             "modifiables_fields": self.modifiables_fields,
         }
+
+    async def send_notifications(self, message, mention_requester):
+        asyncio.run(self.send_message_to_thread(message=message,
+                                                thread_ts=self.requesters_ts,
+                                                channel=self.requesters_channel,
+                                                mention_requester=True))
+
+        asyncio.run(self.send_message_to_thread(message=message,
+                                                thread_ts=self.approvers_ts,
+                                                channel=self.channel_id,
+                                                mention_requester=True))

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -103,16 +103,7 @@ class SlackRequest:
                         },
                         "value": value,
                         "style": "danger",
-                        "action_id": "Rejected",
-                        "confirm": {
-                            "title": {"type": "plain_text", "text": "Confirm", },
-                            "text": {"type": "mrkdwn", "text": "Are you sure?", },
-                            "confirm": {"type": "plain_text", "text": "Do it"},
-                            "deny": {
-                                "type": "plain_text",
-                                "text": "Stop, I've changed my mind!",
-                            },
-                        },
+                        "action_id": "Rejected"
                     },
                 ],
             }

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -104,6 +104,15 @@ class SlackRequest:
                         "value": value,
                         "style": "danger",
                         "action_id": "Rejected",
+                        "confirm": {
+                            "title": {"type": "plain_text", "text": "Confirm", },
+                            "text": {"type": "mrkdwn", "text": "Are you sure?", },
+                            "confirm": {"type": "plain_text", "text": "Do it"},
+                            "deny": {
+                                "type": "plain_text",
+                                "text": "Stop, I've changed my mind!",
+                            },
+                        },
                     },
                 ],
             }

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -77,6 +77,7 @@ class SlackRequest:
             # Save timestamp and requesters channel to be updated after provision
             self.value["ts"] = response.get("ts")
             self.value["requesters_channel"] = self.requesters_channel
+            self.value["approvers_channel"] = self.approvers_channel
         except errors.SlackApiError as e:
             logger.error(e)
         value = json.dumps(self.value)

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -129,7 +129,6 @@ class SlackRequest:
                             "text": "Edit",
                         },
                         "value": value,
-                        "style": "default",
                         "action_id": "Edit",
                     },
                 ],

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -51,41 +51,6 @@ class SlackRequest:
             if key != "provision_class"
         ]
         blocks.extend(input_blocks)
-        view_modal = {
-  "type": "modal",
-  "callback_id": "gratitude-modal",
-  "title": {
-    "type": "plain_text",
-    "text": "Gratitude Box",
-    "emoji": True
-  },
-  "submit": {
-    "type": "plain_text",
-    "text": "Submit",
-    "emoji": True
-  },
-  "close": {
-    "type": "plain_text",
-    "text": "Cancel",
-    "emoji": True
-  },
-  "blocks": [
-    {
-      "type": "input",
-      "block_id": "my_block",
-      "element": {
-        "type": "plain_text_input",
-        "action_id": "my_action"
-      },
-      "label": {
-        "type": "plain_text",
-        "text": "Say something nice!",
-        "emoji": True
-      }
-    }
-  ]
-}
-        blocks.extend(view_modal)
         # First send to requesters channel
         try:
             response = slack_web_client.chat_postMessage(

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -113,6 +113,21 @@ class SlackRequest:
                                 "text": "Stop, I've changed my mind!"
                             }
                         }
+                    },
+                    {
+                        "type":"input",
+                        "label": {
+                            "type": "plain_text",
+                            "text": "Reject"
+                        },
+                        "element": {
+                            "type": "plain_text_input",
+                            "action_id": "reason_response",
+                            "placeholder": {
+                                "type": "plain_text",
+                                "text": "Type reason for reject"
+                            }
+                        }
                     }
                 ],
             }

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -103,12 +103,36 @@ class SlackRequest:
                         },
                         "value": value,
                         "style": "danger",
-                        "action_id": "Rejected"
+                        "action_id": "Rejected",
+                        "confirm": {
+                            "title": {"type": "plain_text", "text": "Reject", },
+                            "text": {"type": "mrkdwn", "text": "Type reason", },
+                            "confirm": {"type": "plain_text", "text": "Do it"},
+                            "deny": {
+                                "type": "plain_text",
+                                "text": "Stop, I've changed my mind!"
+                            }
+                        }
                     }
                 ],
             }
         )
-
+        blocks.append(
+                       {
+                           "type": "input",
+                           "label": {
+                               "type": "plain_text",
+                               "text": "Reject"
+                           },
+                           "element": {
+                               "type": "plain_text_input",
+                               "action_id": "reason_response",
+                               "placeholder": {
+                                   "type": "plain_text",
+                                   "text": "Type reason for reject"
+                               }
+                           }
+                       }})
         # Send to approvers channel with `approve` and `reject` buttons
         try:
             response = slack_web_client.chat_postMessage(

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -71,6 +71,5 @@ class SlackRequest:
             response = slack_web_client.chat_postMessage(
                 channel=self.approvers_channel, text="fallback", blocks=blocks
             )
-            logger.info(response.status_code)
         except errors.SlackApiError as e:
             logger.error(e)

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -13,7 +13,7 @@ class SlackRequest:
         """
         self.inputs = request.json
         self.name = self.inputs["provision_class"]
-        self.value = self.inputs.copy() # save inputs before hiding anything
+        self.value = self.inputs.copy()  # save inputs before hiding anything
         hide = self.inputs.get("hide")
         if hide:
             logger.info(f"Hidden fields: {hide}")
@@ -26,7 +26,7 @@ class SlackRequest:
 
         if self.inputs.get("requesters_channel"):
             self.inputs.pop("requesters_channel")
-        
+
         if self.inputs.get("approvers_channel"):
             self.inputs.pop("approvers_channel")
 
@@ -35,7 +35,7 @@ class SlackRequest:
         blocks = [
             {
                 "type": "header",
-                "text": {"type": "plain_text", "text": self.name, "emoji": True,},
+                "text": {"type": "plain_text", "text": self.name, "emoji": True, },
             },
             {"type": "divider"},
         ]
@@ -57,12 +57,12 @@ class SlackRequest:
                 channel=self.requesters_channel,
                 text="fallback",
                 blocks=blocks
-                + [
-                    {
-                        "type": "section",
-                        "text": {"type": "mrkdwn", "text": "*Request Pending*",},
-                    }
-                ],
+                       + [
+                           {
+                               "type": "section",
+                               "text": {"type": "mrkdwn", "text": "*Request Pending*", },
+                           }
+                       ],
             )
             # Save timestamp and requesters channel to be updated after provision
             self.value["ts"] = response.get("ts")
@@ -85,8 +85,8 @@ class SlackRequest:
                         "action_id": "Approved",
                         "value": value,
                         "confirm": {
-                            "title": {"type": "plain_text", "text": "Confirm",},
-                            "text": {"type": "mrkdwn", "text": "Are you sure?",},
+                            "title": {"type": "plain_text", "text": "Confirm", },
+                            "text": {"type": "mrkdwn", "text": "Are you sure?", },
                             "confirm": {"type": "plain_text", "text": "Do it"},
                             "deny": {
                                 "type": "plain_text",
@@ -104,35 +104,10 @@ class SlackRequest:
                         "value": value,
                         "style": "danger",
                         "action_id": "Rejected",
-                        "confirm": {
-                            "title": {"type": "plain_text", "text": "Reject", },
-                            "text": {"type": "mrkdwn", "text": "Type reason", },
-                            "confirm": {"type": "plain_text", "text": "Do it"},
-                            "deny": {
-                                "type": "plain_text",
-                                "text": "Stop, I've changed my mind!"
-                            }
-                        }
-                    }
+                    },
                 ],
             }
         )
-        blocks.append(
-                       {
-                           "type": "input",
-                           "label": {
-                               "type": "plain_text",
-                               "text": "Reject"
-                           },
-                           "element": {
-                               "type": "plain_text_input",
-                               "action_id": "reason_response",
-                               "placeholder": {
-                                   "type": "plain_text",
-                                   "text": "Type reason for reject"
-                               }
-                           }
-                       }})
         # Send to approvers channel with `approve` and `reject` buttons
         try:
             response = slack_web_client.chat_postMessage(

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -51,6 +51,41 @@ class SlackRequest:
             if key != "provision_class"
         ]
         blocks.extend(input_blocks)
+        view_modal = {
+  "type": "modal",
+  "callback_id": "gratitude-modal",
+  "title": {
+    "type": "plain_text",
+    "text": "Gratitude Box",
+    "emoji": True
+  },
+  "submit": {
+    "type": "plain_text",
+    "text": "Submit",
+    "emoji": True
+  },
+  "close": {
+    "type": "plain_text",
+    "text": "Cancel",
+    "emoji": True
+  },
+  "blocks": [
+    {
+      "type": "input",
+      "block_id": "my_block",
+      "element": {
+        "type": "plain_text_input",
+        "action_id": "my_action"
+      },
+      "label": {
+        "type": "plain_text",
+        "text": "Say something nice!",
+        "emoji": True
+      }
+    }
+  ]
+}
+        blocks.extend(view_modal)
         # First send to requesters channel
         try:
             response = slack_web_client.chat_postMessage(

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -58,7 +58,7 @@ class SlackRequest:
                 ],
             )
             # Save timestamp and requesters channel to be updated after provision
-            self.value["ts"] = response.get("ts")
+            self.value["requesters_ts"] = response.get("ts")
             self.value["requesters_channel"] = self.requesters_channel
             self.value["approvers_channel"] = self.approvers_channel
         except errors.SlackApiError as e:

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -121,6 +121,17 @@ class SlackRequest:
                         "style": "danger",
                         "action_id": "Rejected",
                     },
+                    {
+                        "type": "button",
+                        "text": {
+                            "type": "plain_text",
+                            "emoji": True,
+                            "text": "Edit",
+                        },
+                        "value": value,
+                        "style": "default",
+                        "action_id": "Edit",
+                    },
                 ],
             }
         )

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -62,14 +62,14 @@ class SlackRequest:
             self.value["requesters_channel"] = self.requesters_channel
             self.value["approvers_channel"] = self.approvers_channel
         except errors.SlackApiError as e:
-            logger.error(e)
+            logger.error(e, stack_info=True, exc_info=True)
         value = json.dumps(self.value)
 
         blocks.extend(get_buttons_blocks(value))
 
         # Send to approvers channel with `approve` and `reject` buttons
         try:
-            response = slack_web_client.chat_postMessage(
+            slack_web_client.chat_postMessage(
                 channel=self.approvers_channel, text="fallback", blocks=blocks
             )
         except errors.SlackApiError as e:

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -39,28 +39,6 @@ class SlackRequest:
         slack_web_client = WebClient(self.token)
         blocks = []
         blocks.extend(get_header_block(self.name))
-        #     [
-        #     {
-        #         "type": "header",
-        #         "text": {
-        #             "type": "plain_text",
-        #             "text": self.name,
-        #             "emoji": True,
-        #         },
-        #     },
-        #     {"type": "divider"},
-        # ]
-        # input_blocks = [
-        #     {
-        #         "type": "section",
-        #         "text": {
-        #             "type": "mrkdwn",
-        #             "text": f"*{' '.join([s.capitalize() for s in key.split('_')])}:* {value}",
-        #         },
-        #     }
-        #     for key, value in self.inputs.items()
-        #     if key != "provision_class"
-        # ]
         blocks.extend(get_inputs_blocks(self.inputs))
         # First send to requesters channel
         try:
@@ -84,60 +62,7 @@ class SlackRequest:
         except errors.SlackApiError as e:
             logger.error(e)
         value = json.dumps(self.value)
-        # blocks.append(
-        #     {
-        #         "type": "actions",
-        #         "elements": [
-        #             {
-        #                 "type": "button",
-        #                 "text": {
-        #                     "type": "plain_text",
-        #                     "emoji": True,
-        #                     "text": "Approve",
-        #                 },
-        #                 "style": "primary",
-        #                 "action_id": "Approved",
-        #                 "value": value,
-        #                 "confirm": {
-        #                     "title": {
-        #                         "type": "plain_text",
-        #                         "text": "Confirm",
-        #                     },
-        #                     "text": {
-        #                         "type": "mrkdwn",
-        #                         "text": "Are you sure?",
-        #                     },
-        #                     "confirm": {"type": "plain_text", "text": "Do it"},
-        #                     "deny": {
-        #                         "type": "plain_text",
-        #                         "text": "Stop, I've changed my mind!",
-        #                     },
-        #                 },
-        #             },
-        #             {
-        #                 "type": "button",
-        #                 "text": {
-        #                     "type": "plain_text",
-        #                     "emoji": True,
-        #                     "text": "Reject",
-        #                 },
-        #                 "value": value,
-        #                 "style": "danger",
-        #                 "action_id": "Rejected",
-        #             },
-        #             {
-        #                 "type": "button",
-        #                 "text": {
-        #                     "type": "plain_text",
-        #                     "emoji": True,
-        #                     "text": "Edit",
-        #                 },
-        #                 "value": value,
-        #                 "action_id": "Edit",
-        #             },
-        #         ],
-        #     }
-        # )
+
         blocks.extend(get_buttons_blocks(value))
         # Send to approvers channel with `approve` and `reject` buttons
         try:

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -17,7 +17,6 @@ class SlackRequest:
         self.value = self.inputs.copy()  # save inputs before hiding anything
         hide = self.inputs.get("hide")
         if hide:
-            logger.info(f"Hidden fields: {hide}")
             for field in hide:
                 self.inputs.pop(field, None)
             self.inputs.pop("hide")
@@ -35,7 +34,6 @@ class SlackRequest:
         if self.inputs.get("approvers_channel"):
             self.inputs.pop("approvers_channel")
 
-        logger.info(f"first inputs {self.inputs}")
 
     def send_request_message(self):
         slack_web_client = WebClient(self.token)
@@ -66,7 +64,6 @@ class SlackRequest:
         except errors.SlackApiError as e:
             logger.error(e, stack_info=True, exc_info=True)
         value = json.dumps(self.value)
-        logger.info(f"values inputs {value}")
 
         blocks.extend(get_buttons_blocks(value))
 
@@ -76,4 +73,4 @@ class SlackRequest:
                 channel=self.approvers_channel, text="fallback", blocks=blocks
             )
         except errors.SlackApiError as e:
-            logger.error(e)
+            logger.error(e, stack_info=True, exc_info=True)

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -117,7 +117,7 @@ class SlackRequest:
                 ],
             }
         )
-        blocks.append({{"type": "divider"},
+        blocks.append(
                        {
                            "type": "input",
                            "label": {
@@ -132,7 +132,7 @@ class SlackRequest:
                                    "text": "Type reason for reject"
                                }
                            }
-                       }})
+                       })
         # Send to approvers channel with `approve` and `reject` buttons
         try:
             response = slack_web_client.chat_postMessage(

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -35,6 +35,8 @@ class SlackRequest:
         if self.inputs.get("approvers_channel"):
             self.inputs.pop("approvers_channel")
 
+        logger.info(f"first inputs {self.inputs}")
+
     def send_request_message(self):
         slack_web_client = WebClient(self.token)
         blocks = []
@@ -64,6 +66,7 @@ class SlackRequest:
         except errors.SlackApiError as e:
             logger.error(e, stack_info=True, exc_info=True)
         value = json.dumps(self.value)
+        logger.info(f"values inputs {value}")
 
         blocks.extend(get_buttons_blocks(value))
 

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -103,36 +103,12 @@ class SlackRequest:
                         },
                         "value": value,
                         "style": "danger",
-                        "action_id": "Rejected",
-                        "confirm": {
-                            "title": {"type": "plain_text", "text": "Reject", },
-                            "text": {"type": "mrkdwn", "text": "Type reason", },
-                            "confirm": {"type": "plain_text", "text": "Do it"},
-                            "deny": {
-                                "type": "plain_text",
-                                "text": "Stop, I've changed my mind!"
-                            }
-                        }
+                        "action_id": "Rejected"
                     }
                 ],
             }
         )
-        blocks.append(
-                       {
-                           "type": "input",
-                           "label": {
-                               "type": "plain_text",
-                               "text": "Reject"
-                           },
-                           "element": {
-                               "type": "plain_text_input",
-                               "action_id": "reason_response",
-                               "placeholder": {
-                                   "type": "plain_text",
-                                   "text": "Type reason for reject"
-                               }
-                           }
-                       })
+
         # Send to approvers channel with `approve` and `reject` buttons
         try:
             response = slack_web_client.chat_postMessage(

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -111,26 +111,24 @@ class SlackRequest:
                             "deny": {
                                 "type": "plain_text",
                                 "text": "Stop, I've changed my mind!"
-                            },
-                            "reason": {
-                                {
-                                    "type": "input",
-                                    "label": {
-                                        "type": "plain_text",
-                                        "text": "Reject"
-                                    },
-                                    "element": {
-                                        "type": "plain_text_input",
-                                        "action_id": "reason_response",
-                                        "placeholder": {
-                                            "type": "plain_text",
-                                            "text": "Type reason"
-                                        }
-                                    }
-                                }
                             }
                         }
                     },
+                    {
+                        "type": "input",
+                        "label": {
+                            "type": "plain_text",
+                            "text": "Reject"
+                        },
+                        "element": {
+                            "type": "plain_text_input",
+                            "action_id": "reason_response",
+                            "placeholder": {
+                                "type": "plain_text",
+                                "text": "Type reason for reject"
+                            }
+                        }
+                    }
                 ],
             }
         )

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -9,8 +9,7 @@ logger.setLevel(logging.DEBUG)
 
 class SlackRequest:
     def __init__(self, request):
-        """requesters_channel only necessary for `pending` messages
-        """
+        """requesters_channel only necessary for `pending` messages"""
         self.inputs = request.json
         self.name = self.inputs["provision_class"]
         self.value = self.inputs.copy()  # save inputs before hiding anything
@@ -21,8 +20,12 @@ class SlackRequest:
                 self.inputs.pop(field, None)
             self.inputs.pop("hide")
         self.token = os.environ.get("SLACK_BOT_TOKEN")
-        self.approvers_channel = os.environ[self.inputs.get("approvers_channel", "APPROVERS_CHANNEL")]
-        self.requesters_channel = os.environ[self.inputs.get("requesters_channel", "REQUESTERS_CHANNEL")]
+        self.approvers_channel = os.environ[
+            self.inputs.get("approvers_channel", "APPROVERS_CHANNEL")
+        ]
+        self.requesters_channel = os.environ[
+            self.inputs.get("requesters_channel", "REQUESTERS_CHANNEL")
+        ]
 
         if self.inputs.get("requesters_channel"):
             self.inputs.pop("requesters_channel")
@@ -35,7 +38,11 @@ class SlackRequest:
         blocks = [
             {
                 "type": "header",
-                "text": {"type": "plain_text", "text": self.name, "emoji": True, },
+                "text": {
+                    "type": "plain_text",
+                    "text": self.name,
+                    "emoji": True,
+                },
             },
             {"type": "divider"},
         ]
@@ -57,12 +64,15 @@ class SlackRequest:
                 channel=self.requesters_channel,
                 text="fallback",
                 blocks=blocks
-                       + [
-                           {
-                               "type": "section",
-                               "text": {"type": "mrkdwn", "text": "*Request Pending*", },
-                           }
-                       ],
+                + [
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "*Request Pending*",
+                        },
+                    }
+                ],
             )
             # Save timestamp and requesters channel to be updated after provision
             self.value["ts"] = response.get("ts")
@@ -85,8 +95,14 @@ class SlackRequest:
                         "action_id": "Approved",
                         "value": value,
                         "confirm": {
-                            "title": {"type": "plain_text", "text": "Confirm", },
-                            "text": {"type": "mrkdwn", "text": "Are you sure?", },
+                            "title": {
+                                "type": "plain_text",
+                                "text": "Confirm",
+                            },
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": "Are you sure?",
+                            },
                             "confirm": {"type": "plain_text", "text": "Do it"},
                             "deny": {
                                 "type": "plain_text",
@@ -103,7 +119,7 @@ class SlackRequest:
                         },
                         "value": value,
                         "style": "danger",
-                        "action_id": "Rejected"
+                        "action_id": "Rejected",
                     },
                 ],
             }

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -113,25 +113,26 @@ class SlackRequest:
                                 "text": "Stop, I've changed my mind!"
                             }
                         }
-                    },
-                    {
-                        "type": "input",
-                        "label": {
-                            "type": "plain_text",
-                            "text": "Reject"
-                        },
-                        "element": {
-                            "type": "plain_text_input",
-                            "action_id": "reason_response",
-                            "placeholder": {
-                                "type": "plain_text",
-                                "text": "Type reason for reject"
-                            }
-                        }
                     }
                 ],
             }
         )
+        blocks.append({{"type": "divider"},
+                       {
+                           "type": "input",
+                           "label": {
+                               "type": "plain_text",
+                               "text": "Reject"
+                           },
+                           "element": {
+                               "type": "plain_text_input",
+                               "action_id": "reason_response",
+                               "placeholder": {
+                                   "type": "plain_text",
+                                   "text": "Type reason for reject"
+                               }
+                           }
+                       }})
         # Send to approvers channel with `approve` and `reject` buttons
         try:
             response = slack_web_client.chat_postMessage(

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -60,6 +60,7 @@ class SlackRequest:
             # Save timestamp and requesters channel to be updated after provision
             self.value["ts"] = response.get("ts")
             self.value["requesters_channel"] = self.requesters_channel
+            self.value["approvers_channel"] = self.approvers_channel
         except errors.SlackApiError as e:
             logger.error(e)
         value = json.dumps(self.value)

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -77,7 +77,6 @@ class SlackRequest:
             # Save timestamp and requesters channel to be updated after provision
             self.value["ts"] = response.get("ts")
             self.value["requesters_channel"] = self.requesters_channel
-            self.value["approvers_channel"] = self.approvers_channel
         except errors.SlackApiError as e:
             logger.error(e)
         value = json.dumps(self.value)

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -113,21 +113,6 @@ class SlackRequest:
                                 "text": "Stop, I've changed my mind!"
                             }
                         }
-                    },
-                    {
-                        "type":"input",
-                        "label": {
-                            "type": "plain_text",
-                            "text": "Reject"
-                        },
-                        "element": {
-                            "type": "plain_text_input",
-                            "action_id": "reason_response",
-                            "placeholder": {
-                                "type": "plain_text",
-                                "text": "Type reason for reject"
-                            }
-                        }
                     }
                 ],
             }

--- a/slack_approval/slack_request.py
+++ b/slack_approval/slack_request.py
@@ -35,6 +35,7 @@ class SlackRequest:
             self.inputs.pop("approvers_channel")
 
 
+
     def send_request_message(self):
         slack_web_client = WebClient(self.token)
         blocks = []
@@ -65,7 +66,8 @@ class SlackRequest:
             logger.error(e, stack_info=True, exc_info=True)
         value = json.dumps(self.value)
 
-        blocks.extend(get_buttons_blocks(value))
+        edit_button = self.inputs.get("modifiables_fields", None) is not None and self.inputs.get("modifiables_fields") != ""
+        blocks.extend(get_buttons_blocks(value, edit_button = edit_button))
 
         # Send to approvers channel with `approve` and `reject` buttons
         try:

--- a/slack_approval/utils.py
+++ b/slack_approval/utils.py
@@ -27,12 +27,13 @@ def get_inputs_blocks(inputs):
     return input_block
 
 
-def get_status_block(status, user):
+def get_status_block(status, user, mention_requester=False, user_id=None):
+    mention = f"<@{user_id}>" if mention_requester and user_id is not None else ""
     return [{
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"*Status: {status} by {user}*"
+                "text": f"{mention}*Status: {status} by {user}*"
             }
         }]
 

--- a/slack_approval/utils.py
+++ b/slack_approval/utils.py
@@ -33,7 +33,7 @@ def get_status_block(status, user, mention_requester=False, user_id=None):
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"{mention}*Status: {status} by {user}*"
+                "text": f"*Status: {status} by {user}* {mention}"
             }
         }]
 

--- a/slack_approval/utils.py
+++ b/slack_approval/utils.py
@@ -32,8 +32,8 @@ def get_status_block(status, user):
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"*Status: {status} by {self.user}*",
-            },
+                "text": f"*Status: {status} by {user}*"
+            }
         }]
 
 def get_exception_block(exception):

--- a/slack_approval/utils.py
+++ b/slack_approval/utils.py
@@ -49,11 +49,8 @@ def get_exception_block(exception):
         }
     ]
 
-def get_buttons_blocks(value):
-    return [{
-                "type": "actions",
-                "elements": [
-                    {
+def get_accepted_button(value):
+    return {
                         "type": "button",
                         "text": {
                             "type": "plain_text",
@@ -78,8 +75,10 @@ def get_buttons_blocks(value):
                                 "text": "Stop, I've changed my mind!",
                             },
                         },
-                    },
-                    {
+                    }
+
+def get_rejected_button(value):
+    return {
                         "type": "button",
                         "text": {
                             "type": "plain_text",
@@ -89,8 +88,10 @@ def get_buttons_blocks(value):
                         "value": value,
                         "style": "danger",
                         "action_id": "Rejected",
-                    },
-                    {
+                    }
+
+def get_edit_button(value):
+    return {
                         "type": "button",
                         "text": {
                             "type": "plain_text",
@@ -99,6 +100,12 @@ def get_buttons_blocks(value):
                         },
                         "value": value,
                         "action_id": "Edit",
-                    },
-                ],
+                    }
+def get_buttons_blocks(value, edit_button = False):
+    buttons = [get_accepted_button(value), get_rejected_button(value)]
+    if edit_button:
+        buttons.append(get_edit_button(value))
+    return [{
+                "type": "actions",
+                "elements": buttons,
             }]

--- a/slack_approval/utils.py
+++ b/slack_approval/utils.py
@@ -21,7 +21,7 @@ def get_inputs_blocks(inputs):
             },
         }
         for key, value in inputs.items()
-        if key != "provision_class" and key != "modifiables_fields"
+        if key != "provision_class" and key != "modifiables_fields" and key != "modified"
     ]
     input_block.append({"type": "divider"})
     return input_block

--- a/slack_approval/utils.py
+++ b/slack_approval/utils.py
@@ -21,7 +21,7 @@ def get_inputs_blocks(inputs):
             },
         }
         for key, value in inputs.items()
-        if key != "provision_class" and key != "modified"
+        if key != "provision_class" and key != "modifiables_fields"
     ]
     input_block.append({"type": "divider"})
     return input_block

--- a/slack_approval/utils.py
+++ b/slack_approval/utils.py
@@ -1,0 +1,103 @@
+
+def get_header_block(name):
+    return [{
+        "type": "header",
+        "text": {
+            "type": "plain_text",
+            "text": name,
+            "emoji": True,
+        },
+    },
+    {"type": "divider"}]
+
+
+def get_inputs_blocks(inputs):
+    input_block : list = [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"*{' '.join([s.capitalize() for s in key.split('_')])}:* {value}",
+            },
+        }
+        for key, value in inputs.items()
+        if key != "provision_class"
+    ]
+    input_block.append({"type": "divider"})
+    return input_block
+
+
+def get_status_block(status, user):
+    return [{
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"*Status: {status} by {self.user}*",
+            },
+        }]
+
+def get_exception_block(exception):
+    return [
+        {"type": "divider"},
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"Error while provisioning: {exception}",
+            },
+        }
+    ]
+
+def get_buttons_blocks(value):
+    return [{
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "text": {
+                            "type": "plain_text",
+                            "emoji": True,
+                            "text": "Approve",
+                        },
+                        "style": "primary",
+                        "action_id": "Approved",
+                        "value": value,
+                        "confirm": {
+                            "title": {
+                                "type": "plain_text",
+                                "text": "Confirm",
+                            },
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": "Are you sure?",
+                            },
+                            "confirm": {"type": "plain_text", "text": "Do it"},
+                            "deny": {
+                                "type": "plain_text",
+                                "text": "Stop, I've changed my mind!",
+                            },
+                        },
+                    },
+                    {
+                        "type": "button",
+                        "text": {
+                            "type": "plain_text",
+                            "emoji": True,
+                            "text": "Reject",
+                        },
+                        "value": value,
+                        "style": "danger",
+                        "action_id": "Rejected",
+                    },
+                    {
+                        "type": "button",
+                        "text": {
+                            "type": "plain_text",
+                            "emoji": True,
+                            "text": "Edit",
+                        },
+                        "value": value,
+                        "action_id": "Edit",
+                    },
+                ],
+            }]

--- a/slack_approval/utils.py
+++ b/slack_approval/utils.py
@@ -21,7 +21,7 @@ def get_inputs_blocks(inputs):
             },
         }
         for key, value in inputs.items()
-        if key != "provision_class"
+        if key != "provision_class" and key != "modified"
     ]
     input_block.append({"type": "divider"})
     return input_block


### PR DESCRIPTION
Related to https://premisedata.atlassian.net/browse/INFRA-1497

Changes to slack-request to handle modifiables inputs.  approvers_channel will be passed to slack-provision-
Changes to slack-provision mostly refactors to make reusable all the send messages method. Added mention for the requester on actions. Added flow for edit modifiables fields optional. All the messages send to the slack request in response to request are now async so should not be errors at the moment of actions because delay (slack force 3 seconds no more).
Utils are added to handle blocks constructions because now are also needed in the slack-provision side also. 

Change release will be added soon. README will be updated once all the prod release will be tested.